### PR TITLE
Filter brews view

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -60,6 +60,7 @@ import { MillEditModal } from '../pages/mill/edit/mill-edit';
 import { MillsPage } from '../pages/mill/mills';
 /** Pipes */
 import { FormatDatePipe } from '../pipes/formatDate';
+import { SearchPipe } from '../pipes/search';
 import { KeysPipe } from '../pipes/keys';
 import { ToDecimalPipe } from '../pipes/toDecimal';
 import { UIAlert } from '../services/uiAlert';
@@ -93,6 +94,7 @@ import { UIStorage } from '../services/uiStorage';
     MillAddModal,
     MillEditModal,
     FormatDatePipe,
+    SearchPipe,
     KeysPipe,
     ToDecimalPipe,
     PreventCharacterDirective,

--- a/src/pages/brews/brews.html
+++ b/src/pages/brews/brews.html
@@ -48,7 +48,7 @@
           {{brewView.title}}
         </ion-list-header>
 
-        <ion-card *ngFor="let brew of brewView.brews | search:'bean,method_of_preparation,mill':query">
+        <ion-card *ngFor="let brew of brewView.brews | searchBrew:query">
           <ion-card-header>
             {{brew.formateDate("HH:mm")}}
           </ion-card-header>

--- a/src/pages/brews/brews.html
+++ b/src/pages/brews/brews.html
@@ -44,11 +44,11 @@
         Keine Einträge vorhanden.
       </ion-card>
       <ion-list *ngFor="let brewView of openBrewsView">
-        <ion-list-header class="brews-header">
+        <ion-list-header class="brews-header" *ngIf="(brewView.brews | searchBrews:query).length > 0">
           {{brewView.title}}
         </ion-list-header>
 
-        <ion-card *ngFor="let brew of brewView.brews | searchBrew:query">
+        <ion-card *ngFor="let brew of brewView.brews | searchBrews:query">
           <ion-card-header>
             {{brew.formateDate("HH:mm")}}
           </ion-card-header>
@@ -141,7 +141,7 @@
         <ion-list-header class="brews-header">
           {{brewView.title}}
         </ion-list-header>
-        <ion-card *ngFor="let brew of brewView.brews">
+        <ion-card *ngFor="let brew of brewView.brews | searchBrews:query">
 
           <ion-card-header>
             {{brew.formateDate("HH:mm")}}

--- a/src/pages/brews/brews.html
+++ b/src/pages/brews/brews.html
@@ -29,6 +29,10 @@
     </ion-segment>
   </div>
   <div [ngSwitch]="brew_segment">
+      <ion-item>
+        <ion-label stacked>Filter (Bohnen, Methode, Mühle)</ion-label>
+        <ion-input [(ngModel)]="query" type="text"></ion-input>
+      </ion-item>
     <div *ngSwitchCase="'open'">
       <ion-card  padding *ngIf="!uiBrewHelper.canBrew()">
         <h2 class="error-text">Um einen Bezug zu starten, lege bitte eine <b>Bohnensorte</b> sowie eine <b>Zubereitungsmethode</b> und <b>Mühle</b> an.</h2>
@@ -44,8 +48,7 @@
           {{brewView.title}}
         </ion-list-header>
 
-        <input [(ngModel)]="query">
-        <ion-card *ngFor="let brew of brewView.brews | search:'bean,method_of_preparation':query">
+        <ion-card *ngFor="let brew of brewView.brews | search:'bean,method_of_preparation,mill':query">
           <ion-card-header>
             {{brew.formateDate("HH:mm")}}
           </ion-card-header>

--- a/src/pages/brews/brews.html
+++ b/src/pages/brews/brews.html
@@ -43,8 +43,9 @@
         <ion-list-header class="brews-header">
           {{brewView.title}}
         </ion-list-header>
-        <ion-card *ngFor="let brew of brewView.brews">
 
+        <input [(ngModel)]="query">
+        <ion-card *ngFor="let brew of brewView.brews | search:'bean,method_of_preparation':query">
           <ion-card-header>
             {{brew.formateDate("HH:mm")}}
           </ion-card-header>

--- a/src/pipes/search.ts
+++ b/src/pipes/search.ts
@@ -1,0 +1,14 @@
+import {Pipe, PipeTransform} from '@angular/core';
+
+// see this SO answer: https://stackoverflow.com/a/44764070/1629640
+@Pipe({
+  name: 'search'
+})
+export class SearchPipe implements PipeTransform {
+  public transform(value, keys: string, term: string) {
+
+    if (!term) return value;
+    return (value || []).filter(item => keys.split(',').some(key => item.hasOwnProperty(key) && new RegExp(term, 'gi').test(item[key])));
+
+  }
+}

--- a/src/pipes/search.ts
+++ b/src/pipes/search.ts
@@ -2,7 +2,7 @@ import {Pipe, PipeTransform} from '@angular/core';
 
 // see this SO answer: https://stackoverflow.com/a/44764070/1629640
 @Pipe({
-  name: 'searchBrew'
+  name: 'searchBrews'
 })
 export class SearchPipe implements PipeTransform {
   public transform(brews: Array<Brew>, query: string) {

--- a/src/pipes/search.ts
+++ b/src/pipes/search.ts
@@ -2,13 +2,20 @@ import {Pipe, PipeTransform} from '@angular/core';
 
 // see this SO answer: https://stackoverflow.com/a/44764070/1629640
 @Pipe({
-  name: 'search'
+  name: 'searchBrew'
 })
 export class SearchPipe implements PipeTransform {
-  public transform(value, keys: string, term: string) {
+  public transform(brews: Array<Brew>, query: string) {
 
-    if (!term) return value;
-    return (value || []).filter(item => keys.split(',').some(key => item.hasOwnProperty(key) && new RegExp(term, 'gi').test(item[key])));
+    if (!query) {
+      return brews;
+    }
 
+    const matchesQuery = prop => new RegExp(query, 'gi').test(prop);
+    const relevantProperties = (brew: Brew) => [brew.getBean().name, brew.getMill().name, brew.getPreparation().name];
+
+    return (brews || []).filter(
+      brew => relevantProperties(brew).some(matchesQuery)
+    )
   }
 }


### PR DESCRIPTION
Add an input at the top of the brews view that allows the user to filter the available brews.
Currently bean name / mill name / method of preparation are searched for the entered filter.

This should allow the user to answer questions such as "How did I prepare these beans the last time I used them" quicker than scrolling through the list of old brews.