### PR TITLE
Disambiguate Acaia Timer Buttons

### DIFF
--- a/src/classes/devices/acaia/acaia.ts
+++ b/src/classes/devices/acaia/acaia.ts
@@ -368,6 +368,13 @@ export class AcaiaScale {
           this.callback(EventType.WEIGHT, this.weight);
           this.logger.debug('weight: ' + msg.weight + ' ' + Date.now());
         } else if (msg.msgType === ScaleMessageType.TARE_START_STOP_RESET) {
+          if (msg.button === "unknown") {
+            if (this.timer_running) {
+              msg.button = Button.STOP;
+            } else if (this.paused_time > 0) {
+              msg.button = Button.RESET;
+            }
+          }
           switch (msg.button) {
             case Button.TARE:
               this.weight = 0;

--- a/src/components/brews/brew-brewing/brew-brewing.component.ts
+++ b/src/components/brews/brew-brewing/brew-brewing.component.ts
@@ -220,6 +220,9 @@ export class BrewBrewingComponent implements OnInit, AfterViewInit {
               case SCALE_TIMER_COMMAND.STOP:
                 this.timer.pauseTimer();
                 break;
+              case SCALE_TIMER_COMMAND.RESET:
+                this.timer.reset();
+                break;
             }
           } else {
             if (this.timer.isTimerRunning() === true) {


### PR DESCRIPTION
When pausing and resetting the timer the bluetooth messages send "unknown" button. I followed the logic that the scale uses to disambiguate these in our code and get timer control in the app from the scale button. Because this logic is implemented using our side of the code instead of directly from the scale lots of testing would be appreciated! I've done significant testing on my side and don't seem to get any mismatches between the app/scale states but more tests would be preferred to guarantee we have something stable

*Note:* This does not solve the issue of automatic timer/taring modes :( Still trying to figure this part out as the bluetooth messages don't seem to contain this information