### PR TITLE
brews & beans filtered count

### DIFF
--- a/src/app/app.scss
+++ b/src/app/app.scss
@@ -853,4 +853,19 @@ ion-menu:host .menu-inner {
   color: white !important;
 }
 
+ion-segment.tabs {
+  display: flex;
+  flex-direction: row;
+  flex-grow: 1;
 
+  padding-top:0px;
+
+  ion-segment-button{
+    width: 100%; 
+
+    .value{
+      font-size: 14px;
+      opacity: 0.8;
+    }
+  }
+}

--- a/src/app/beans/beans.page.html
+++ b/src/app/beans/beans.page.html
@@ -24,7 +24,10 @@
       <ion-label>
         {{"PAGE_BEANS_LIST_OBTAINABLE" | translate}}
         <br />
-        <span class="value">( {{ openBeans?.length }} / {{ beans.length - finishedBeans?.length }} )</span>
+        <span class="value" *ngIf="isFilterActive()">
+          ( {{ openBeans?.length }} / {{ beans.length - finishedBeans?.length }} )
+        </span>
+        <span class="value" *ngIf="!isFilterActive()">( {{ openBeans?.length }} )</span>
       </ion-label>
     </ion-segment-button>
     <ion-segment-button *ngIf="settings?.show_archived_beans" value="archiv">

--- a/src/app/beans/beans.page.html
+++ b/src/app/beans/beans.page.html
@@ -24,17 +24,24 @@
       <ion-label>
         {{"PAGE_BEANS_LIST_OBTAINABLE" | translate}}
         <br />
-        <span class="value" *ngIf="isFilterActive()">
-          ( {{ openBeans?.length }} / {{ beans.length - finishedBeans?.length }} )
+        <span class="value" *ngIf="isFilterActive() && bean_segment === 'open'; else openCountSimplified">
+          ( {{ openBeans?.length }} / {{ openBeansLength }} )
         </span>
-        <span class="value" *ngIf="!isFilterActive()">( {{ openBeans?.length }} )</span>
+        <ng-template #openCountSimplified>
+          <span class="value">( {{ openBeansLength }} )</span>
+        </ng-template>
       </ion-label>
     </ion-segment-button>
     <ion-segment-button *ngIf="settings?.show_archived_beans" value="archiv">
       <ion-label>
         {{"TAB_ARCHIVE" | translate}}
-        <br />
-        <span class="value">( {{ finishedBeans?.length }} )</span>
+        <br /> 
+        <span class="value" *ngIf="isFilterActive() && bean_segment === 'archiv'; else finishedCountSimplified">
+          ( {{ finishedBeans?.length }} / {{ finishedBeansLength }} )
+        </span>
+        <ng-template #finishedCountSimplified>
+          <span class="value">( {{ finishedBeansLength }} )</span>
+        </ng-template>
       </ion-label>
     </ion-segment-button>
   </ion-segment>

--- a/src/app/beans/beans.page.html
+++ b/src/app/beans/beans.page.html
@@ -32,11 +32,11 @@
         </ng-template>
       </ion-label>
     </ion-segment-button>
-    <ion-segment-button *ngIf="settings?.show_archived_beans" value="archiv">
+    <ion-segment-button *ngIf="settings?.show_archived_beans" value="archive">
       <ion-label>
         {{"TAB_ARCHIVE" | translate}}
         <br /> 
-        <span class="value" *ngIf="isFilterActive() && bean_segment === 'archiv'; else finishedCountSimplified">
+        <span class="value" *ngIf="isFilterActive() && bean_segment === 'archive'; else finishedCountSimplified">
           ( {{ finishedBeans?.length }} / {{ finishedBeansLength }} )
         </span>
         <ng-template #finishedCountSimplified>
@@ -81,7 +81,7 @@
 
     </div>
     <div *ngIf="settings?.show_archived_beans">
-      <div *ngSwitchCase="'archiv'">
+      <div *ngSwitchCase="'archive'">
         <div *ngIf="finishedBeans?.length > 0 || shallBarBeDisplayed() || isTextSearchActive() || isFilterActive() || isSortActive()" class="ion-justify-content-end container" style="margin-left:10px;margin-right:10px;margin-bottom:20px;">
 
           <ion-searchbar (ionChange)="research()" [(ngModel)]="archivedBeansFilterText" class="ion-no-padding ion-no-margin" debounce="750" placeholder="{{'SEARCH' | translate}}" search-icon="beanconqueror-detail" showCancelButton="never"></ion-searchbar>

--- a/src/app/beans/beans.page.html
+++ b/src/app/beans/beans.page.html
@@ -21,7 +21,7 @@
 
   <ion-segment (ionChange)="segmentChanged()" [(ngModel)]="bean_segment" class="ion-padding-vertical" style="padding-top:0px;">
     <ion-segment-button value="open">
-      <ion-label>{{"PAGE_BEANS_LIST_OBTAINABLE" | translate}}
+      <ion-label>{{"PAGE_BEANS_LIST_OBTAINABLE" | translate}} ( {{ openBeans?.length }} / {{ beans.length }} )
       </ion-label>
     </ion-segment-button>
     <ion-segment-button *ngIf="settings?.show_archived_beans" value="archiv">

--- a/src/app/beans/beans.page.html
+++ b/src/app/beans/beans.page.html
@@ -19,13 +19,19 @@
 </ion-header>
 <ion-content #beanContent>
 
-  <ion-segment (ionChange)="segmentChanged()" [(ngModel)]="bean_segment" class="ion-padding-vertical" style="padding-top:0px;">
-    <ion-segment-button value="open">
-      <ion-label>{{"PAGE_BEANS_LIST_OBTAINABLE" | translate}} ( {{ openBeans?.length }} / {{ beans.length }} )
+  <ion-segment (ionChange)="segmentChanged()" [(ngModel)]="bean_segment" class="ion-padding-vertical tabs" >
+    <ion-segment-button value="open"  >
+      <ion-label>
+        {{"PAGE_BEANS_LIST_OBTAINABLE" | translate}}
+        <br />
+        <span class="value">( {{ openBeans?.length }} / {{ beans.length - finishedBeans?.length }} )</span>
       </ion-label>
     </ion-segment-button>
     <ion-segment-button *ngIf="settings?.show_archived_beans" value="archiv">
-      <ion-label>{{"TAB_ARCHIVE" | translate}}
+      <ion-label>
+        {{"TAB_ARCHIVE" | translate}}
+        <br />
+        <span class="value">( {{ finishedBeans?.length }} )</span>
       </ion-label>
     </ion-segment-button>
   </ion-segment>

--- a/src/app/beans/beans.page.ts
+++ b/src/app/beans/beans.page.ts
@@ -49,6 +49,9 @@ export class BeansPage implements OnInit {
   public openBeans: Array<Bean> = [];
   public finishedBeans: Array<Bean> = [];
 
+  public finishedBeansLength: number = 0;
+  public openBeansLength: number = 0;
+
   public openBeansSort: IBeanPageSort = {
     sort_after: BEAN_SORT_AFTER.UNKOWN,
     sort_order: BEAN_SORT_ORDER.UNKOWN,
@@ -64,7 +67,7 @@ export class BeansPage implements OnInit {
   @ViewChild('beanContent', { read: ElementRef })
   public beanContent: ElementRef;
 
-  public bean_segment: string = 'open';
+  public bean_segment: 'open' | 'archiv' = 'open';
   public archivedBeansSort: IBeanPageSort = {
     sort_after: BEAN_SORT_AFTER.UNKOWN,
     sort_order: BEAN_SORT_ORDER.UNKOWN,
@@ -531,6 +534,12 @@ export class BeansPage implements OnInit {
     this.beans = this.uiBeanStorage
       .getAllEntries()
       .sort((a, b) => a.name.localeCompare(b.name));
+
+    this.openBeansLength = this.beans.reduce(
+      (n, e) => (!e.finished ? n + 1 : n),
+      0
+    );
+    this.finishedBeansLength = this.beans.length - this.openBeansLength;
 
     this.openBeans = [];
     this.finishedBeans = [];

--- a/src/app/beans/beans.page.ts
+++ b/src/app/beans/beans.page.ts
@@ -67,7 +67,7 @@ export class BeansPage implements OnInit {
   @ViewChild('beanContent', { read: ElementRef })
   public beanContent: ElementRef;
 
-  public bean_segment: 'open' | 'archiv' = 'open';
+  public bean_segment: 'open' | 'archive' = 'open';
   public archivedBeansSort: IBeanPageSort = {
     sort_after: BEAN_SORT_AFTER.UNKOWN,
     sort_order: BEAN_SORT_ORDER.UNKOWN,
@@ -544,6 +544,6 @@ export class BeansPage implements OnInit {
     this.openBeans = [];
     this.finishedBeans = [];
     this.__initializeBeansView('open');
-    this.__initializeBeansView('archiv');
+    this.__initializeBeansView('archive');
   }
 }

--- a/src/app/brew/brew.page.html
+++ b/src/app/brew/brew.page.html
@@ -20,7 +20,7 @@
 <ion-content #brewContent>
     <ion-segment (ionChange)="segmentChanged()" [(ngModel)]="brew_segment" class="ion-padding-vertical" style="padding-top:0px;">
       <ion-segment-button value="open">
-        <ion-label>{{"CURRENT" | translate }}
+        <ion-label>{{"CURRENT" | translate }} ( {{ openBrewsView?.length }} / {{ brews?.length }} )
         </ion-label>
       </ion-segment-button>
       <ion-segment-button *ngIf="settings?.show_archived_brews" value="archive">

--- a/src/app/brew/brew.page.html
+++ b/src/app/brew/brew.page.html
@@ -18,13 +18,19 @@
   </ion-toolbar>
 </ion-header>
 <ion-content #brewContent>
-    <ion-segment (ionChange)="segmentChanged()" [(ngModel)]="brew_segment" class="ion-padding-vertical" style="padding-top:0px;">
+    <ion-segment (ionChange)="segmentChanged()" [(ngModel)]="brew_segment" class="ion-padding-vertical tabs" >
       <ion-segment-button value="open">
-        <ion-label>{{"CURRENT" | translate }} ( {{ openBrewsView?.length }} / {{ brews?.length }} )
+        <ion-label>
+          {{"CURRENT" | translate }} 
+          <br/>
+          <span class="value">( {{ openBrewsView?.length }} / {{ brews?.length - archiveBrewsView?.length }} )</span>
         </ion-label>
       </ion-segment-button>
       <ion-segment-button *ngIf="settings?.show_archived_brews" value="archive">
-        <ion-label>{{"TAB_ARCHIVE" | translate }}
+        <ion-label>
+          {{"TAB_ARCHIVE" | translate }}
+          <br/>
+          <span class="value">( {{ archiveBrewsView?.length }} )</span>
         </ion-label>
       </ion-segment-button>
     </ion-segment>

--- a/src/app/brew/brew.page.html
+++ b/src/app/brew/brew.page.html
@@ -23,17 +23,24 @@
         <ion-label>
           {{"CURRENT" | translate }} 
           <br/>
-          <span class="value" *ngIf="isFilterActive()">( {{ openBrewsView?.length }} / {{ brews?.length - archiveBrewsView?.length }} )</span>
-          <span class="value" *ngIf="!isFilterActive()">
-            ( {{ openBrewsView?.length }} )
+          <span class="value" *ngIf="isFilterActive() && brew_segment === 'open'; else openCountSimplified">
+            ( {{ openBrewsView?.length }} / {{ openBrewsLength }} )
           </span>
+          <ng-template #openCountSimplified>
+            <span class="value">( {{ openBrewsLength }} )</span>
+          </ng-template>
         </ion-label>
       </ion-segment-button>
       <ion-segment-button *ngIf="settings?.show_archived_brews" value="archive">
         <ion-label>
           {{"TAB_ARCHIVE" | translate }}
-          <br/>
-          <span class="value">( {{ archiveBrewsView?.length }} )</span>
+          <br/>  
+          <span class="value" *ngIf="isFilterActive() && brew_segment === 'archive'; else archiveCountSimplified">
+            ( {{ archiveBrewsView?.length }} / {{ archiveBrewsLength }} )
+          </span>
+          <ng-template #archiveCountSimplified>
+            <span class="value">( {{ archiveBrewsLength }} )</span>
+          </ng-template>
         </ion-label>
       </ion-segment-button>
     </ion-segment>

--- a/src/app/brew/brew.page.html
+++ b/src/app/brew/brew.page.html
@@ -23,7 +23,10 @@
         <ion-label>
           {{"CURRENT" | translate }} 
           <br/>
-          <span class="value">( {{ openBrewsView?.length }} / {{ brews?.length - archiveBrewsView?.length }} )</span>
+          <span class="value" *ngIf="isFilterActive()">( {{ openBrewsView?.length }} / {{ brews?.length - archiveBrewsView?.length }} )</span>
+          <span class="value" *ngIf="!isFilterActive()">
+            ( {{ openBrewsView?.length }} )
+          </span>
         </ion-label>
       </ion-segment-button>
       <ion-segment-button *ngIf="settings?.show_archived_brews" value="archive">

--- a/src/app/brew/brew.page.ts
+++ b/src/app/brew/brew.page.ts
@@ -27,7 +27,7 @@ import { UIAnalytics } from '../../services/uiAnalytics';
   styleUrls: ['./brew.page.scss'],
 })
 export class BrewPage implements OnInit {
-  private brews: Array<Brew>;
+  public brews: Array<Brew>;
   public openBrewsView: Array<Brew> = [];
   public archiveBrewsView: Array<Brew> = [];
 

--- a/src/app/brew/brew.page.ts
+++ b/src/app/brew/brew.page.ts
@@ -31,7 +31,10 @@ export class BrewPage implements OnInit {
   public openBrewsView: Array<Brew> = [];
   public archiveBrewsView: Array<Brew> = [];
 
-  public brew_segment: string = 'open';
+  public openBrewsLength: number = 0;
+  public archiveBrewsLength: number = 0;
+
+  public brew_segment: 'open' | 'archive' = 'open';
 
   @ViewChild('openScroll', { read: AgVirtualSrollComponent, static: false })
   public openScroll: AgVirtualSrollComponent;
@@ -115,6 +118,12 @@ export class BrewPage implements OnInit {
     this.brews = this.uiBrewStorage.getAllEntries();
     this.openBrewsView = [];
     this.archiveBrewsView = [];
+
+    this.openBrewsLength = this.brews.reduce(
+      (n, e) => (!e.getBean().finished ? n + 1 : n),
+      0
+    );
+    this.archiveBrewsLength = this.brews.length - this.openBrewsLength;
 
     this.__initializeBrewView('open');
     this.__initializeBrewView('archiv');

--- a/src/app/mill/mill.page.html
+++ b/src/app/mill/mill.page.html
@@ -15,17 +15,19 @@
 </ion-header>
 
 <ion-content #millContent>
-  <ion-segment (ionChange)="segmentChanged()" [(ngModel)]="segment" class="ion-padding-vertical" style="padding-top:0px;">
+  <ion-segment (ionChange)="segmentChanged()" [(ngModel)]="segment" class="ion-padding-vertical tabs">
     <ion-segment-button value="open">
-      <ion-label>{{"CURRENT" | translate }}
+      <ion-label>
+        {{"CURRENT" | translate }}
       </ion-label>
     </ion-segment-button>
     <ion-segment-button *ngIf="settings?.show_archived_mills" value="archive">
-      <ion-label>{{"TAB_ARCHIVE" | translate }}
+      <ion-label>
+        {{"TAB_ARCHIVE" | translate }}
       </ion-label>
-
     </ion-segment-button>
   </ion-segment>
+
   <div [ngSwitch]="segment">
     <div *ngSwitchCase="'open'">
       <div *ngIf="getActiveMills()?.length == 0" class="ion-padding ion-text-center">

--- a/src/app/preparation/preparation.page.html
+++ b/src/app/preparation/preparation.page.html
@@ -14,16 +14,19 @@
   </ion-toolbar>
 </ion-header>
 <ion-content #preparationContent>
-  <ion-segment (ionChange)="segmentChanged()"  [(ngModel)]="segment" class="ion-padding-vertical" style="padding-top:0px;">
+  <ion-segment (ionChange)="segmentChanged()" [(ngModel)]="segment" class="ion-padding-vertical class">
     <ion-segment-button value="open">
-      <ion-label>{{"CURRENT" | translate }}
+      <ion-label>
+        {{"CURRENT" | translate }}
       </ion-label>
     </ion-segment-button>
     <ion-segment-button *ngIf="settings?.show_archived_preparations" value="archive">
-      <ion-label>{{"TAB_ARCHIVE" | translate }}
+      <ion-label>
+        {{"TAB_ARCHIVE" | translate }}
       </ion-label>
     </ion-segment-button>
   </ion-segment>
+
   <div [ngSwitch]="segment">
     <div *ngSwitchCase="'open'">
       <div *ngIf="openPreparationsView?.length == 0" class="ion-padding ion-text-center">


### PR DESCRIPTION
issue: #498 

# Changes:
- `tabs` CSS class:  all tabs will have same width + numbers styling  
- use `tabs` CSS class for brews, beans, methods, grinders

# Visual changes:
## Before:
![image](https://user-images.githubusercontent.com/48121710/224495514-c43b301f-46c1-42ba-85d6-96b053acbc37.png)
## After:
### If there aren't any active filters:
![image](https://user-images.githubusercontent.com/48121710/224495406-e2d861ee-d426-405d-aa5f-5e4903641724.png)
### If there are active filters on the current tab:
![image](https://user-images.githubusercontent.com/48121710/224495436-b215d0ab-c474-4738-9535-085046733e9b.png)
![image](https://user-images.githubusercontent.com/48121710/224495699-aec98b46-9778-423f-a5b3-385de9708acd.png)
### If there are filters but `Available` tab is not active:
![image](https://user-images.githubusercontent.com/48121710/224495469-1726c202-95ce-4f85-898c-4ef58888d0b0.png)

### Brews page:
- looks and works in the same way as on `beans` page

![image](https://user-images.githubusercontent.com/48121710/224495602-ce7f7dd6-5557-467a-afc9-937a1dea00be.png)
![image](https://user-images.githubusercontent.com/48121710/224495637-d19c3003-c262-41ff-93ad-f66c96ebd2e7.png)
