### PR TITLE
Fix for labels overflowing under elements 

### DIFF
--- a/src/app/settings/settings.page.scss
+++ b/src/app/settings/settings.page.scss
@@ -29,4 +29,13 @@
     }
 
   }
+
+  .ion-label {
+    white-space: break-spaces;
+
+    h2 {
+      text-overflow: clip;
+      white-space: break-spaces;
+    }
+  }
 }


### PR DESCRIPTION
It happened a lot with Italian translation so I tried an easy fix.

| Before | After |
| ------ | ------ |
| ![image](https://github.com/graphefruit/Beanconqueror/assets/11654389/8192a6b1-4997-46d3-9338-bb0a114004bd)| ![image](https://github.com/graphefruit/Beanconqueror/assets/11654389/eed63641-e140-408d-bf3a-6e40f25db3af)| 
