### PR TITLE
Resolve warning about legacy label syntax for ion-checkbox.

### DIFF
--- a/src/popover/qr-code-scanner-popover/qr-code-scanner-popover.component.html
+++ b/src/popover/qr-code-scanner-popover/qr-code-scanner-popover.component.html
@@ -14,9 +14,10 @@
 <ion-footer class="ion-no-border">
 
   <ion-item class="ion-padding-horizontal" lines="none">
-    <ion-label>{{"DONT_SHOW_AGAIN" | translate}}</ion-label>
     <ion-checkbox (ngModelChange)="saveSettings();"
-                  [(ngModel)]="settings.qr_scanner_information"></ion-checkbox>
+                  [(ngModel)]="settings.qr_scanner_information">
+      {{"DONT_SHOW_AGAIN" | translate}}
+    </ion-checkbox>
   </ion-item>
   <ion-row class="ion-padding-top">
 


### PR DESCRIPTION
https://ionicframework.com/docs/api/checkbox#using-the-modern-syntax

This seems to be the only place where `ion-label` was used with `ion-checkbox` in this way.