### PR TITLE
Move frozenId to right side of bean info w/ roast range & rating

### DIFF
--- a/src/components/bean-information/bean-information.component.html
+++ b/src/components/bean-information/bean-information.component.html
@@ -1,39 +1,41 @@
 <ion-card  class="long-card" tappable (click)="showBean()" (long-press)="longPressEditBean($event)">
   <ion-card-content #card  class="no-ion-col-vertical-padding ion-padding-top">
-    <ion-grid class="no-padding-bottom">
+    <ion-grid class="no-padding-bottom no-padding-top">
       <ion-row>
-        <ion-col [size]="((bean?.roast_range!== 0 && uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.roast_range)) || (bean?.rating !== 0 &&  uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.rating)))?8:11" style="margin: auto 0;">
-          <div class="ion-no-padding font-size-20 ion-title bean-title">
-            <ion-icon style="top: 3px;position: relative;margin-right:5px;" name="snow-outline"
-                      *ngIf="bean.isFrozen()"></ion-icon>
-            <span *ngIf='bean.isFrozen() === false && bean.frozenId' style='margin-right:5px;'>(<ion-icon style="top: 3px;position: relative;" name="snow-outline"></ion-icon>)</span>
-            <ion-icon style="top: 3px;position: relative;margin-right:5px;" name="flame-outline"
-                      *ngIf="bean.isSelfRoasted()"></ion-icon>
-            <ion-icon style="top: 3px;position: relative;margin-right:5px;" name="qr-code-outline"
-                      *ngIf="bean.isScannedBean()"></ion-icon>
-            <ion-icon style="top: 3px;position: relative;margin-right:5px;" name="share-social-outline"
-                      *ngIf="bean.shared"></ion-icon>
-
-            <ion-icon style="top: 3px;position: relative;margin-right:5px;" name="heart"
-                      *ngIf="bean.favourite"></ion-icon>
-            <span *ngIf='bean.frozenId'><ion-icon style='margin-bottom: -4px;' name="pricetag-outline"></ion-icon>&nbsp;[{{bean.frozenId}}]&nbsp;-&nbsp;</span>{{bean.name}}&nbsp;<span
-            *ngIf="!isBeanRoastUnknown() && uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.bean_roasting_type)">({{"BEAN_ROASTING_TYPE_" + bean.bean_roasting_type | translate}})</span>
+        <ion-col class="expand-fill-space" style="margin: auto 0;">
+          <div class="ion-no-padding font-size-20 ion-title no-overflow-ellipsis center-icons-to-text add-child-margin">
+            <ion-icon name="snow-outline" *ngIf="bean.isFrozen()">&nbsp;</ion-icon>
+            <div *ngIf='bean.isFrozen() === false && bean.frozenId' style="display: flex;">
+              (<ion-icon name="snow-outline"></ion-icon>)
+            </div>
+            <ion-icon name="flame-outline" *ngIf="bean.isSelfRoasted()"></ion-icon>
+            <ion-icon name="qr-code-outline" *ngIf="bean.isScannedBean()"></ion-icon>
+            <ion-icon name="share-social-outline" *ngIf="bean.shared"></ion-icon>
+            <ion-icon name="heart" *ngIf="bean.favourite"></ion-icon>
+            <div class="ion-justify-content-start center-icons-to-text expand-fill-space">
+              <div class="expand-fill-space no-overflow-ellipsis" style="margin-right:-5px;">
+                {{bean.name}}&nbsp;
+                <span *ngIf="!isBeanRoastUnknown() && uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.bean_roasting_type)">
+                  ({{"BEAN_ROASTING_TYPE_" + bean.bean_roasting_type | translate}})
+                </span>
+              </div>
+            </div>
           </div>
         </ion-col>
-        <ion-col *ngIf="((bean?.roast_range!== 0 && uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.roast_range)) || (bean?.rating !== 0 &&  uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.rating)))" size="3">
-
+        <ion-col size="auto" class="stacked-info children-force-newline hide-if-empty">
+          <div *ngIf='bean.frozenId' class="ion-justify-content-end center-icons-to-text frozen-id-label">
+            <ion-icon name="pricetag-outline"></ion-icon>
+            <div>
+              {{bean.frozenId}}
+            </div>
+          </div>
           <ngx-stars #beanStars *ngIf="bean?.roast_range !== 0 && uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.roast_range)" [initialStars]="bean.roast_range" [readonly]="true"
                      [size]="1" class="bean-display ion-float-right"></ngx-stars>
-          <div style="clear:both;" *ngIf="bean?.roast_range !== 0 && bean?.rating !== 0"></div>
-
           <ngx-stars #beanRating *ngIf="bean?.rating !== 0 && uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.rating) && hasCustomRatingRange() === false" [color]="'#BFB9B0'" [initialStars]="bean.rating"
-                     [maxStars]="5" [readonly]="true" [wholeStars]="true" class="ion-float-right brew-stars">
-          </ngx-stars>
-          <div  *ngIf="bean?.rating > 0 && uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.rating)  && hasCustomRatingRange() === true" class="ion-text-right">
+                     [maxStars]="5" [readonly]="true" [wholeStars]="true" class="ion-float-right brew-stars"></ngx-stars>
+          <div *ngIf="bean?.rating > 0 && uiBeanHelper.fieldVisible(settings.bean_visible_list_view_parameters.rating)  && hasCustomRatingRange() === true" class="ion-text-right">
               <ion-badge>{{this.uiHelper.toFixedIfNecessary(bean.rating,2)}}</ion-badge>
           </div>
-
-
         </ion-col>
         <ion-col size="1" *ngIf="showActions">
           <ion-button (click)="showBeanActions($event)" class="button-top-absolute" color="accent" fill="clear">

--- a/src/components/bean-information/bean-information.component.scss
+++ b/src/components/bean-information/bean-information.component.scss
@@ -13,12 +13,70 @@
       padding-top: var(--padding-top);
     }
   }
+  .no-overflow {
+    overflow: hidden;
+  }
 
-  .bean-title{
+  .no-overflow-ellipsis {
     white-space: nowrap;
     text-overflow: ellipsis;
     overflow: hidden;
   }
+
+  .add-child-margin {
+    > *:not(:last-child) {
+      margin-right: 5px;
+    }
+  }
+
+  .center-icons-to-text {
+    display: flex;
+    ion-icon {
+      flex: none;
+    }
+  }
+
+  .expand-fill-space {
+    flex-grow: 1;
+    min-width: 0;
+  }
+
+  .children-force-newline > * {
+    // you can override this for a specific child eg by `clear: none !important;`
+    clear: both;
+  }
+
+  .hide-if-empty:empty {
+    display: none;
+  }
+
+  .stacked-info {
+    margin-top: -10px;
+    padding-left: 0px;
+    line-height: normal;
+    align-items: center;
+    flex-wrap: wrap;
+    text-align: right;
+    > *:only-child {
+      margin-top: 12px;
+    }
+  }
+
+  .frozen-id-label {
+    font-size: 17px;
+    display: flex;
+    align-items: center;
+    text-align: right;
+    margin-bottom: 4px;
+    color: var(--ion-color-medium) !important;
+    > *{
+      color: inherit !important;
+    }
+    ion-icon {
+      max-width: 0.8rem;
+    }
+  }
+
   // Overwrite
   .button-top-absolute {
     position: absolute;


### PR DESCRIPTION
## Scope of Changes
Changes limited to the bean-information component's html and scss files, and only affect the title row where each bean's name is displayed.  This change does not affect anywhere else the frozenId value is displayed (eg when selecting beans for a brew, nothing is changed).

## Major(ish) Changes
- Move the frozenId label from the left side into the horizontal stack on the right side, alongside the roast level and rating.

## Minor Changes
- Make the "column" containing the bean name expandable with flex-grow and auto sized others to allow name to take up maximum allowable space until ellipses overflow
- Allow the horizontal stack on the right side to use some negative margin to reduce impact of multiple stacked items taking up space. Also reduce line spacing for same reason.

## Cleanup / Quality-of-life Changes
- Simplify clear fix for stacked rightside column by having applicable elements clear themselves
- Simplify display criteria for stacked rightside column by using :empty instead of ngIf conditional
- Clean up a few repeated style items into classes, such as adding margin to all but the last child, etc

## QA:
- I tested with bean names of varying lengths
- I tested with multiple left-icons visible (eg favorite, etc)
- I tested with all permutations of items that can be displayed in the right-side stack: FreezeId, Roast Level, Rating Stars, Rating number
- I tested with screen sizes from exceptionally narrow to landscape tablet size
- Sample screenshots for various screen sizes are attached.

[localhost_4200_home_beans (1)](https://github.com/user-attachments/assets/2464944d-1593-42ce-ae69-923b1b168029)
[localhost_4200_home_beans](https://github.com/user-attachments/assets/330f11d5-620f-4d49-ae48-055f4c3a27b6)
[localhost_4200_home_beans(iPhone 12 Pro) (1)](https://github.com/user-attachments/assets/e377ac95-5bfd-4a9d-bd81-3b09806e62ca)
[localhost_4200_home_beans(iPhone 12 Pro)](https://github.com/user-attachments/assets/4a972c32-e482-464f-a045-0e51aecda03c)
[localhost_4200_home_beans(iPad Air) (3)](https://github.com/user-attachments/assets/068c48dd-5d58-4047-af65-ad064992a519)
[localhost_4200_home_beans(iPad Air) (2)](https://github.com/user-attachments/assets/6d4b3734-827d-4f38-a752-8ba65bc39209)
