### PR TITLE
Fix test after latest changes and fix flaky test.

### DIFF
--- a/src/app/beans/bean-archive-popover/bean-archive-popover.component.spec.ts
+++ b/src/app/beans/bean-archive-popover/bean-archive-popover.component.spec.ts
@@ -7,8 +7,8 @@ import { UIToast } from '../../../services/uiToast';
 import { UISettingsStorage } from '../../../services/uiSettingsStorage';
 import { Settings } from '../../../classes/settings/settings';
 import { UIHelper } from '../../../services/uiHelper';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { TranslateServiceMock } from '../../../classes/mock';
+import { TranslateModule } from '@ngx-translate/core';
+import { FormsModule } from '@angular/forms';
 
 describe('BeanArchivePopoverComponent', () => {
   let component: BeanArchivePopoverComponent;
@@ -18,8 +18,13 @@ describe('BeanArchivePopoverComponent', () => {
     const settingsMock = {} as Settings;
 
     TestBed.configureTestingModule({
-      declarations: [BeanArchivePopoverComponent, TranslatePipe],
-      imports: [IonicModule.forRoot()],
+      declarations: [BeanArchivePopoverComponent],
+      imports: [
+        IonicModule.forRoot(),
+        TranslateModule.forRoot(),
+        TranslateModule.forChild(),
+        FormsModule,
+      ],
       providers: [
         {
           provide: UIBeanStorage,
@@ -42,10 +47,6 @@ describe('BeanArchivePopoverComponent', () => {
           useValue: {
             toFixedIfNecessary: (_value, _dp): number => 0,
           } as UIHelper,
-        },
-        {
-          provide: TranslateService,
-          useValue: TranslateServiceMock,
         },
       ],
     }).compileComponents();

--- a/src/app/beans/bean-filter/bean-filter.component.spec.ts
+++ b/src/app/beans/bean-filter/bean-filter.component.spec.ts
@@ -9,10 +9,10 @@ import { UIPreparationStorage } from '../../../services/uiPreparationStorage';
 import { UIBeanStorage } from '../../../services/uiBeanStorage';
 import { UIMillStorage } from '../../../services/uiMillStorage';
 import { IBeanPageFilter } from '../../../interfaces/bean/iBeanPageFilter';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
 import { TranslateServiceMock } from '../../../classes/mock';
 import { FormsModule } from '@angular/forms';
-import { KeysPipe } from '../../../pipes/keys';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BeanFilterComponent', () => {
   let component: BeanFilterComponent;
@@ -39,8 +39,13 @@ describe('BeanFilterComponent', () => {
       },
     } as Settings;
     TestBed.configureTestingModule({
-      declarations: [BeanFilterComponent, TranslatePipe, KeysPipe],
-      imports: [IonicModule.forRoot(), FormsModule],
+      declarations: [BeanFilterComponent],
+      imports: [
+        IonicModule.forRoot(),
+        FormsModule,
+        PipesModule,
+        TranslateModule.forChild(),
+      ],
       providers: [
         {
           provide: UIHelper,

--- a/src/app/beans/bean-popover-actions/bean-popover-actions.component.spec.ts
+++ b/src/app/beans/bean-popover-actions/bean-popover-actions.component.spec.ts
@@ -5,8 +5,8 @@ import { BeanPopoverActionsComponent } from './bean-popover-actions.component';
 import { UIHelper } from '../../../services/uiHelper';
 import { UIBeanHelper } from '../../../services/uiBeanHelper';
 import { IBean } from '../../../interfaces/bean/iBean';
-import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import { TranslateServiceMock } from '../../../classes/mock';
+import { IonicStorageModule } from '@ionic/storage-angular';
+import { TranslateModule } from '@ngx-translate/core';
 
 describe('BeanPopoverActionsComponent', () => {
   let component: BeanPopoverActionsComponent;
@@ -14,8 +14,13 @@ describe('BeanPopoverActionsComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [BeanPopoverActionsComponent, TranslatePipe],
-      imports: [IonicModule.forRoot()],
+      declarations: [BeanPopoverActionsComponent],
+      imports: [
+        IonicModule.forRoot(),
+        IonicStorageModule.forRoot(),
+        TranslateModule.forRoot(),
+        TranslateModule.forChild(),
+      ],
       providers: [
         {
           provide: NavParams,
@@ -39,17 +44,15 @@ describe('BeanPopoverActionsComponent', () => {
           provide: UIBeanHelper,
           useValue: {},
         },
-        {
-          provide: TranslateService,
-          useValue: TranslateServiceMock,
-        },
       ],
     }).compileComponents();
+  }));
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(BeanPopoverActionsComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/beans/bean-popover-freeze/bean-popover-freeze.component.spec.ts
+++ b/src/app/beans/bean-popover-freeze/bean-popover-freeze.component.spec.ts
@@ -2,6 +2,12 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { BeanPopoverFreezeComponent } from './bean-popover-freeze.component';
+import { IonicStorageModule } from '@ionic/storage-angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { UIHelper } from 'src/services/uiHelper';
+import { UIHelperMock } from 'src/classes/mock';
+import { PipesModule } from 'src/pipes/PipesModule';
+import { Bean } from 'src/classes/bean/bean';
 
 describe('BeanPopoverFreezeComponent', () => {
   let component: BeanPopoverFreezeComponent;
@@ -10,13 +16,23 @@ describe('BeanPopoverFreezeComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [BeanPopoverFreezeComponent],
-      imports: [IonicModule.forRoot()],
+      imports: [
+        IonicModule.forRoot(),
+        IonicStorageModule.forRoot(),
+        TranslateModule.forChild(),
+        TranslateModule.forRoot(),
+        PipesModule,
+      ],
+      providers: [{ provide: UIHelper, useClass: UIHelperMock }],
     }).compileComponents();
+  }));
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(BeanPopoverFreezeComponent);
     component = fixture.componentInstance;
+    component.bean = new Bean();
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/beans/bean-popover-freeze/bean-popover-freeze.component.spec.ts
+++ b/src/app/beans/bean-popover-freeze/bean-popover-freeze.component.spec.ts
@@ -6,7 +6,7 @@ import { IonicStorageModule } from '@ionic/storage-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { UIHelper } from 'src/services/uiHelper';
 import { UIHelperMock } from 'src/classes/mock';
-import { PipesModule } from 'src/pipes/PipesModule';
+import { PipesModule } from 'src/pipes/pipes.module';
 import { Bean } from 'src/classes/bean/bean';
 
 describe('BeanPopoverFreezeComponent', () => {

--- a/src/app/beans/bean-popover-frozen-list/bean-popover-frozen-list.component.spec.ts
+++ b/src/app/beans/bean-popover-frozen-list/bean-popover-frozen-list.component.spec.ts
@@ -1,7 +1,11 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { IonicModule } from '@ionic/angular';
 
 import { BeanPopoverFrozenListComponent } from './bean-popover-frozen-list.component';
+import { IonicStorageModule } from '@ionic/storage-angular';
+import { TranslateModule, TranslateService } from '@ngx-translate/core';
+import { UIHelperMock } from 'src/classes/mock';
+import { UIHelper } from 'src/services/uiHelper';
+import { IonicModule } from '@ionic/angular';
 
 describe('BeanPopoverFrozenListComponent', () => {
   let component: BeanPopoverFrozenListComponent;
@@ -10,13 +14,21 @@ describe('BeanPopoverFrozenListComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [BeanPopoverFrozenListComponent],
-      imports: [IonicModule.forRoot()],
+      imports: [
+        IonicModule.forRoot(),
+        IonicStorageModule.forRoot(),
+        TranslateModule.forChild(),
+        TranslateModule.forRoot(),
+      ],
+      providers: [{ provide: UIHelper, useClass: UIHelperMock }],
     }).compileComponents();
+  }));
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(BeanPopoverFrozenListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/beans/beans-add/beans-add.component.spec.ts
+++ b/src/app/beans/beans-add/beans-add.component.spec.ts
@@ -4,7 +4,6 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { BeansAddComponent } from './beans-add.component';
 import { TranslateModule } from '@ngx-translate/core';
 
-import { KeysPipe } from '../../../pipes/keys';
 import { FormsModule } from '@angular/forms';
 import { IonicModule, ModalController } from '@ionic/angular';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
@@ -21,6 +20,7 @@ import { UIAnalytics } from '../../../services/uiAnalytics';
 import { UIBeanHelper } from '../../../services/uiBeanHelper';
 import { UISettingsStorage } from '../../../services/uiSettingsStorage';
 import { Settings } from '../../../classes/settings/settings';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BeansAddComponent', () => {
   let component: BeansAddComponent;
@@ -38,8 +38,9 @@ describe('BeansAddComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [BeansAddComponent, KeysPipe],
+      declarations: [BeansAddComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/beans/beans-edit/beans-edit.component.spec.ts
+++ b/src/app/beans/beans-edit/beans-edit.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { File } from '@awesome-cordova-plugins/file/ngx';
 import { Camera } from '@awesome-cordova-plugins/camera/ngx';
@@ -19,6 +18,7 @@ import { UIAnalytics } from '../../../services/uiAnalytics';
 import { UIBeanHelper } from '../../../services/uiBeanHelper';
 import { UISettingsStorage } from '../../../services/uiSettingsStorage';
 import { Settings } from '../../../classes/settings/settings';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BeansEditComponent', () => {
   let component: BeansEditComponent;
@@ -32,8 +32,9 @@ describe('BeansEditComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [BeansEditComponent, KeysPipe, AsyncImageComponent],
+      declarations: [BeansEditComponent, AsyncImageComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/beans/beans.page.spec.ts
+++ b/src/app/beans/beans.page.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController } from '@ionic/angular';
-import { KeysPipe } from '../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { File } from '@awesome-cordova-plugins/file/ngx';
 import { Camera } from '@awesome-cordova-plugins/camera/ngx';
@@ -14,12 +13,12 @@ import { ImagePicker } from '@awesome-cordova-plugins/image-picker/ngx';
 import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions/ngx';
 import { Router } from '@angular/router';
 import { AsyncImageComponent } from '../../components/async-image/async-image.component';
-import { FormatDatePipe } from '../../pipes/formatDate';
 import { UIBeanStorage } from '../../services/uiBeanStorage';
 import { UISettingsStorage } from '../../services/uiSettingsStorage';
 import { UIAnalytics } from '../../services/uiAnalytics';
 import { IntentHandlerService } from '../../services/intentHandler/intent-handler.service';
 import { UIBeanHelper } from '../../services/uiBeanHelper';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BeansPage', () => {
   let component: BeansPage;
@@ -32,8 +31,9 @@ describe('BeansPage', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [BeansPage, KeysPipe, AsyncImageComponent, FormatDatePipe],
+      declarations: [BeansPage, AsyncImageComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/brew/brew-add/brew-add.component.spec.ts
+++ b/src/app/brew/brew-add/brew-add.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock, UIHelperMock } from '../../../classes/mock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -14,7 +13,6 @@ import { Camera } from '@awesome-cordova-plugins/camera/ngx';
 import { ImagePicker } from '@awesome-cordova-plugins/image-picker/ngx';
 import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions/ngx';
 import { Router } from '@angular/router';
-import { FormatDatePipe } from '../../../pipes/formatDate';
 import { BrewTimerComponent } from '../../../components/brew-timer/brew-timer.component';
 import { AsyncImageComponent } from '../../../components/async-image/async-image.component';
 import { UIBeanStorage } from '../../../services/uiBeanStorage';
@@ -34,6 +32,7 @@ import { Preparation } from '../../../classes/preparation/preparation';
 import { Mill } from '../../../classes/mill/mill';
 import { SocialSharing } from '@awesome-cordova-plugins/social-sharing/ngx';
 import { UIHelper } from '../../../services/uiHelper';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BrewAddComponent', () => {
   let component: BrewAddComponent;
@@ -47,14 +46,9 @@ describe('BrewAddComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [
-        BrewAddComponent,
-        KeysPipe,
-        FormatDatePipe,
-        BrewTimerComponent,
-        AsyncImageComponent,
-      ],
+      declarations: [BrewAddComponent, BrewTimerComponent, AsyncImageComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/brew/brew-detail/brew-detail.component.spec.ts
+++ b/src/app/brew/brew-detail/brew-detail.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -18,6 +17,7 @@ import { SocialSharing } from '@awesome-cordova-plugins/social-sharing/ngx';
 import { FileTransfer } from '@awesome-cordova-plugins/file-transfer/ngx';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ScreenOrientation } from '@awesome-cordova-plugins/screen-orientation/ngx';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BrewDetailComponent', () => {
   let component: BrewDetailComponent;
@@ -31,8 +31,9 @@ describe('BrewDetailComponent', () => {
         CommonModule,
         IonicModule,
         HttpClientTestingModule,
+        PipesModule,
       ],
-      declarations: [BrewDetailComponent, KeysPipe],
+      declarations: [BrewDetailComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/brew/brew-edit/brew-edit.component.spec.ts
+++ b/src/app/brew/brew-edit/brew-edit.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -15,11 +14,11 @@ import { ImagePicker } from '@awesome-cordova-plugins/image-picker/ngx';
 import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions/ngx';
 import { Router } from '@angular/router';
 import { AsyncImageComponent } from '../../../components/async-image/async-image.component';
-import { FormatDatePipe } from '../../../pipes/formatDate';
 import { SocialSharing } from '@awesome-cordova-plugins/social-sharing/ngx';
 import { FileTransfer } from '@awesome-cordova-plugins/file-transfer/ngx';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Insomnia } from '@awesome-cordova-plugins/insomnia/ngx';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BrewEditComponent', () => {
   let component: BrewEditComponent;
@@ -34,13 +33,9 @@ describe('BrewEditComponent', () => {
         CommonModule,
         IonicModule,
         HttpClientTestingModule,
+        PipesModule,
       ],
-      declarations: [
-        BrewEditComponent,
-        KeysPipe,
-        AsyncImageComponent,
-        FormatDatePipe,
-      ],
+      declarations: [BrewEditComponent, AsyncImageComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/brew/brew-popover-actions/brew-popover-actions.component.spec.ts
+++ b/src/app/brew/brew-popover-actions/brew-popover-actions.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -18,6 +17,7 @@ import { UIHelper } from '../../../services/uiHelper';
 import { UIPreparationStorage } from '../../../services/uiPreparationStorage';
 import { Brew } from '../../../classes/brew/brew';
 import { Preparation } from '../../../classes/preparation/preparation';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BrewPopoverActionsComponent', () => {
   let component: BrewPopoverActionsComponent;
@@ -30,8 +30,9 @@ describe('BrewPopoverActionsComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [BrewPopoverActionsComponent, KeysPipe],
+      declarations: [BrewPopoverActionsComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/brew/brew.page.spec.ts
+++ b/src/app/brew/brew.page.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -18,6 +17,7 @@ import { BrewInformationComponent } from '../../components/brew-information/brew
 import { SocialSharing } from '@awesome-cordova-plugins/social-sharing/ngx';
 import { UIHelper } from '../../services/uiHelper';
 import { UIHelperMock } from '../../classes/mock';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BrewPage', () => {
   let component: BrewPage;
@@ -30,8 +30,9 @@ describe('BrewPage', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [BrewPage, KeysPipe, BrewInformationComponent],
+      declarations: [BrewPage, BrewInformationComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/home/home.page.spec.ts
+++ b/src/app/home/home.page.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { File } from '@awesome-cordova-plugins/file/ngx';
 import { Camera } from '@awesome-cordova-plugins/camera/ngx';
@@ -15,6 +14,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { UIHelper } from '../../services/uiHelper';
 import { NavParamsMock, UIHelperMock } from '../../classes/mock';
 import { RouterTestingModule } from '@angular/router/testing';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('HomePage', () => {
   let component: HomePage;
@@ -28,8 +28,9 @@ describe('HomePage', () => {
         CommonModule,
         IonicModule,
         RouterTestingModule,
+        PipesModule,
       ],
-      declarations: [HomePage, KeysPipe],
+      declarations: [HomePage],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/info/about/about.component.spec.ts
+++ b/src/app/info/about/about.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -15,6 +14,7 @@ import { ImagePicker } from '@awesome-cordova-plugins/image-picker/ngx';
 import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions/ngx';
 import { Router } from '@angular/router';
 import { AppVersion } from '@awesome-cordova-plugins/app-version/ngx';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('AboutComponent', () => {
   let component: AboutComponent;
@@ -27,8 +27,9 @@ describe('AboutComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [AboutComponent, KeysPipe],
+      declarations: [AboutComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/info/contact/contact.component.spec.ts
+++ b/src/app/info/contact/contact.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { Router } from '@angular/router';
 import { UIHelper } from '../../../services/uiHelper';
 import { UIHelperMock } from '../../../classes/mock';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('ContactComponent', () => {
   let component: ContactComponent;
@@ -28,8 +28,9 @@ describe('ContactComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [ContactComponent, KeysPipe],
+      declarations: [ContactComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/info/credits/credits.component.spec.ts
+++ b/src/app/info/credits/credits.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { Router } from '@angular/router';
 import { SocialSharing } from '@awesome-cordova-plugins/social-sharing/ngx';
 import { FileTransfer } from '@awesome-cordova-plugins/file-transfer/ngx';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('CreditsComponent', () => {
   let component: CreditsComponent;
@@ -28,8 +28,9 @@ describe('CreditsComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [CreditsComponent, KeysPipe],
+      declarations: [CreditsComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/info/licences/licences.component.spec.ts
+++ b/src/app/info/licences/licences.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { Router } from '@angular/router';
 import { UIHelper } from '../../../services/uiHelper';
 import { UIHelperMock } from '../../../classes/mock';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('LicencesComponent', () => {
   let component: LicencesComponent;
@@ -28,8 +28,9 @@ describe('LicencesComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [LicencesComponent, KeysPipe],
+      declarations: [LicencesComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/info/log/log.component.spec.ts
+++ b/src/app/info/log/log.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock, UIHelperMock } from '../../../classes/mock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { Router } from '@angular/router';
 import { SocialSharing } from '@awesome-cordova-plugins/social-sharing/ngx';
 import { UIHelper } from '../../../services/uiHelper';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('LogComponent', () => {
   let component: LogComponent;
@@ -28,8 +28,9 @@ describe('LogComponent', () => {
         TranslateModule.forRoot(),
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [LogComponent, KeysPipe],
+      declarations: [LogComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/info/privacy/privacy.component.spec.ts
+++ b/src/app/info/privacy/privacy.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { Router } from '@angular/router';
 import { UIHelper } from '../../../services/uiHelper';
 import { UIHelperMock } from '../../../classes/mock';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('PrivacyComponent', () => {
   let component: PrivacyComponent;
@@ -28,8 +28,9 @@ describe('PrivacyComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [PrivacyComponent, KeysPipe],
+      declarations: [PrivacyComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/info/terms/terms.component.spec.ts
+++ b/src/app/info/terms/terms.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { RouterTestingModule } from '@angular/router/testing';
 import { UIHelper } from '../../../services/uiHelper';
 import { UIHelperMock } from '../../../classes/mock';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('TermsComponent', () => {
   let component: TermsComponent;
@@ -29,8 +29,9 @@ describe('TermsComponent', () => {
         CommonModule,
         IonicModule,
         RouterTestingModule,
+        PipesModule,
       ],
-      declarations: [TermsComponent, KeysPipe],
+      declarations: [TermsComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/info/thanks/thanks.component.spec.ts
+++ b/src/app/info/thanks/thanks.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -14,6 +13,7 @@ import { Camera } from '@awesome-cordova-plugins/camera/ngx';
 import { ImagePicker } from '@awesome-cordova-plugins/image-picker/ngx';
 import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions/ngx';
 import { Router } from '@angular/router';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('ThanksComponent', () => {
   let component: ThanksComponent;
@@ -26,8 +26,9 @@ describe('ThanksComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [ThanksComponent, KeysPipe],
+      declarations: [ThanksComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/mill/mill-add/mill-add.component.spec.ts
+++ b/src/app/mill/mill-add/mill-add.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { Router } from '@angular/router';
 import { UIHelper } from '../../../services/uiHelper';
 import { UIHelperMock } from '../../../classes/mock';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('MillAddComponent', () => {
   let component: MillAddComponent;
@@ -28,8 +28,9 @@ describe('MillAddComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [MillAddComponent, KeysPipe],
+      declarations: [MillAddComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/mill/mill-edit/mill-edit.component.spec.ts
+++ b/src/app/mill/mill-edit/mill-edit.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock, UIHelperMock } from '../../../classes/mock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -15,6 +14,7 @@ import { ImagePicker } from '@awesome-cordova-plugins/image-picker/ngx';
 import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions/ngx';
 import { Router } from '@angular/router';
 import { UIHelper } from '../../../services/uiHelper';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('MillEditComponent', () => {
   let component: MillEditComponent;
@@ -27,8 +27,9 @@ describe('MillEditComponent', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [MillEditComponent, KeysPipe],
+      declarations: [MillEditComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/mill/mill.page.spec.ts
+++ b/src/app/mill/mill.page.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { Router } from '@angular/router';
 import { UIHelper } from '../../services/uiHelper';
 import { UIHelperMock } from '../../classes/mock';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('MillPage', () => {
   let component: MillPage;
@@ -28,8 +28,9 @@ describe('MillPage', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [MillPage, KeysPipe],
+      declarations: [MillPage],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/preparation/preparation-add/preparation-add.component.spec.ts
+++ b/src/app/preparation/preparation-add/preparation-add.component.spec.ts
@@ -3,8 +3,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { PreparationAddComponent } from './preparation-add.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { ModalController } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { UIAnalytics } from '../../../services/uiAnalytics';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('PreparationAddComponent', () => {
   let component: PreparationAddComponent;
@@ -12,8 +12,8 @@ describe('PreparationAddComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [TranslateModule.forRoot()],
-      declarations: [PreparationAddComponent, KeysPipe],
+      imports: [TranslateModule.forRoot(), PipesModule],
+      declarations: [PreparationAddComponent],
       providers: [
         {
           provide: UIAnalytics,

--- a/src/app/preparation/preparation-connected-device/preparation-connected-device.component.spec.ts
+++ b/src/app/preparation/preparation-connected-device/preparation-connected-device.component.spec.ts
@@ -32,7 +32,9 @@ describe('PreparationConnectedDeviceComponent', () => {
         },
       ],
     }).compileComponents();
+  }));
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(PreparationConnectedDeviceComponent);
     component = fixture.componentInstance;
     component.preparation = {
@@ -41,7 +43,7 @@ describe('PreparationConnectedDeviceComponent', () => {
       },
     } as Preparation;
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/preparation/preparation-edit/preparation-edit.component.spec.ts
+++ b/src/app/preparation/preparation-edit/preparation-edit.component.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock, UIHelperMock } from '../../../classes/mock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { Router } from '@angular/router';
 import { UIHelper } from '../../../services/uiHelper';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('PreparationEditComponent', () => {
   let component: PreparationEditComponent;
@@ -29,8 +29,9 @@ describe('PreparationEditComponent', () => {
         CommonModule,
         IonicModule,
         HttpClientTestingModule,
+        PipesModule,
       ],
-      declarations: [PreparationEditComponent, KeysPipe],
+      declarations: [PreparationEditComponent],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/preparation/preparation-sort-tools/preparation-sort-tools.component.spec.ts
+++ b/src/app/preparation/preparation-sort-tools/preparation-sort-tools.component.spec.ts
@@ -2,6 +2,8 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { PreparationSortToolsComponent } from './preparation-sort-tools.component';
+import { TranslateModule } from '@ngx-translate/core';
+import { Preparation } from 'src/classes/preparation/preparation';
 
 describe('PreparationSortToolsComponent', () => {
   let component: PreparationSortToolsComponent;
@@ -10,13 +12,20 @@ describe('PreparationSortToolsComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [PreparationSortToolsComponent],
-      imports: [IonicModule.forRoot()],
+      imports: [
+        IonicModule.forRoot(),
+        TranslateModule.forChild(),
+        TranslateModule.forRoot(),
+      ],
     }).compileComponents();
+  }));
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(PreparationSortToolsComponent);
     component = fixture.componentInstance;
+    component.preparation = new Preparation();
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/app/preparation/preparation.page.spec.ts
+++ b/src/app/preparation/preparation.page.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -17,6 +16,7 @@ import { Router } from '@angular/router';
 import { UIHelper } from '../../services/uiHelper';
 import { UIHelperMock } from '../../classes/mock';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('PreparationPage', () => {
   let component: PreparationPage;
@@ -30,8 +30,9 @@ describe('PreparationPage', () => {
         CommonModule,
         IonicModule,
         HttpClientTestingModule,
+        PipesModule,
       ],
-      declarations: [PreparationPage, KeysPipe],
+      declarations: [PreparationPage],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/settings/settings.page.spec.ts
+++ b/src/app/settings/settings.page.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -21,6 +20,7 @@ import { UIHelperMock } from '../../classes/mock';
 import { UIHelper } from '../../services/uiHelper';
 import { AppVersion } from '@awesome-cordova-plugins/app-version/ngx';
 import { FileTransfer } from '@awesome-cordova-plugins/file-transfer/ngx';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('SettingsPage', () => {
   let component: SettingsPage;
@@ -33,8 +33,9 @@ describe('SettingsPage', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [SettingsPage, KeysPipe],
+      declarations: [SettingsPage],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,7 +1,5 @@
 import { CUSTOM_ELEMENTS_SCHEMA, NgModule } from '@angular/core';
 
-import { FormatDatePipe } from '../../pipes/formatDate';
-import { KeysPipe } from '../../pipes/keys';
 import { CommonModule } from '@angular/common';
 import { IonicModule } from '@ionic/angular';
 import { AsyncImageComponent } from '../../components/async-image/async-image.component';
@@ -52,7 +50,6 @@ import { LogTextComponent } from '../info/log/log-text/log-text.component';
 import { TranslateModule } from '@ngx-translate/core';
 import { Globalization } from '@awesome-cordova-plugins/globalization/ngx';
 import { AppVersion } from '@awesome-cordova-plugins/app-version/ngx';
-import { EnumToArrayPipe } from '../../pipes/enumToArray';
 import { HelperPage } from '../helper/helper.page';
 import { BrewInformationComponent } from '../../components/brew-information/brew-information.component';
 import { CuppingRadarComponent } from '../../components/cupping-radar/cupping-radar.component';
@@ -191,6 +188,7 @@ import { MeticulousHelpPopoverComponent } from '../../popover/meticulous-help-po
 import { BeanPopoverFreezeComponent } from '../beans/bean-popover-freeze/bean-popover-freeze.component';
 import { BeanFreezeInformationComponent } from '../../components/beans/bean-freeze-information/bean-freeze-information.component';
 import { BeanPopoverFrozenListComponent } from '../beans/bean-popover-frozen-list/bean-popover-frozen-list.component';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 @NgModule({
   declarations: [
@@ -273,9 +271,6 @@ import { BeanPopoverFrozenListComponent } from '../beans/bean-popover-frozen-lis
     BrewChoosePreparationToBrewComponent,
     BrewFlavorPickerComponent,
     BrewBeverageQuantityCalculatorComponent,
-    FormatDatePipe,
-    KeysPipe,
-    EnumToArrayPipe,
     AsyncImageComponent,
     BrewInformationComponent,
     BrewGraphReferenceCardComponent,
@@ -368,6 +363,7 @@ import { BeanPopoverFrozenListComponent } from '../beans/bean-popover-frozen-lis
     RouterModule,
     NgxStarsModule,
     AgVirtualScrollModule,
+    PipesModule,
   ],
   providers: [
     AppVersion,
@@ -387,9 +383,6 @@ import { BeanPopoverFrozenListComponent } from '../beans/bean-popover-frozen-lis
     TooltipDirective,
     TransformDateDirective,
     DisableDoubleClickDirective,
-    FormatDatePipe,
-    KeysPipe,
-    EnumToArrayPipe,
     InAppBrowser,
     File,
     Device,
@@ -487,9 +480,6 @@ import { BeanPopoverFrozenListComponent } from '../beans/bean-popover-frozen-lis
     BrewChoosePreparationToBrewComponent,
     BrewFlavorPickerComponent,
     BrewBeverageQuantityCalculatorComponent,
-    FormatDatePipe,
-    KeysPipe,
-    EnumToArrayPipe,
     AsyncImageComponent,
     BrewInformationComponent,
     BrewGraphReferenceCardComponent,

--- a/src/app/statistic/statistic.page.spec.ts
+++ b/src/app/statistic/statistic.page.spec.ts
@@ -6,7 +6,6 @@ import { FormsModule } from '@angular/forms';
 import { Storage } from '@ionic/storage';
 import { CommonModule } from '@angular/common';
 import { IonicModule, ModalController, NavParams } from '@ionic/angular';
-import { KeysPipe } from '../../pipes/keys';
 import { InAppBrowser } from '@awesome-cordova-plugins/in-app-browser/ngx';
 import { NavParamsMock } from '../../classes/mock/NavParamsMock';
 import { File } from '@awesome-cordova-plugins/file/ngx';
@@ -16,6 +15,7 @@ import { AndroidPermissions } from '@awesome-cordova-plugins/android-permissions
 import { Router } from '@angular/router';
 import { UIHelper } from '../../services/uiHelper';
 import { UIHelperMock } from '../../classes/mock';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('StatisticPage', () => {
   let component: StatisticPage;
@@ -28,8 +28,9 @@ describe('StatisticPage', () => {
         FormsModule,
         CommonModule,
         IonicModule,
+        PipesModule,
       ],
-      declarations: [StatisticPage, KeysPipe],
+      declarations: [StatisticPage],
       providers: [
         { provide: InAppBrowser },
         { provide: ModalController },

--- a/src/app/water-section/water/water-add/water-add.component.spec.ts
+++ b/src/app/water-section/water/water-add/water-add.component.spec.ts
@@ -7,7 +7,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { UIHelper } from '../../../../services/uiHelper';
 import { UIHelperMock } from '../../../../classes/mock';
 import { FormsModule } from '@angular/forms';
-import { KeysPipe } from 'src/pipes/keys';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('WaterAddComponent', () => {
   let component: WaterAddComponent;
@@ -15,8 +15,13 @@ describe('WaterAddComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [WaterAddComponent, KeysPipe],
-      imports: [IonicModule.forRoot(), TranslateModule.forRoot(), FormsModule],
+      declarations: [WaterAddComponent],
+      imports: [
+        IonicModule.forRoot(),
+        TranslateModule.forRoot(),
+        FormsModule,
+        PipesModule,
+      ],
       providers: [
         { provide: Storage },
         { provide: UIHelper, useClass: UIHelperMock },

--- a/src/app/water-section/water/water-edit/water-edit.component.spec.ts
+++ b/src/app/water-section/water/water-edit/water-edit.component.spec.ts
@@ -7,7 +7,7 @@ import { TranslateModule } from '@ngx-translate/core';
 import { UIHelper } from '../../../../services/uiHelper';
 import { UIHelperMock } from '../../../../classes/mock';
 import { FormsModule } from '@angular/forms';
-import { KeysPipe } from '../../../../pipes/keys';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('WaterEditComponent', () => {
   let component: WaterEditComponent;
@@ -15,8 +15,13 @@ describe('WaterEditComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [WaterEditComponent, KeysPipe],
-      imports: [IonicModule.forRoot(), TranslateModule.forRoot(), FormsModule],
+      declarations: [WaterEditComponent],
+      imports: [
+        IonicModule.forRoot(),
+        TranslateModule.forRoot(),
+        FormsModule,
+        PipesModule,
+      ],
       providers: [
         { provide: Storage },
         { provide: UIHelper, useClass: UIHelperMock },

--- a/src/components/beans/bean-freeze-information/bean-freeze-information.component.spec.ts
+++ b/src/components/beans/bean-freeze-information/bean-freeze-information.component.spec.ts
@@ -6,7 +6,7 @@ import { IonicStorageModule } from '@ionic/storage-angular';
 import { TranslateModule } from '@ngx-translate/core';
 import { UIHelper } from 'src/services/uiHelper';
 import { UIHelperMock } from 'src/classes/mock';
-import { PipesModule } from 'src/pipes/PipesModule';
+import { PipesModule } from 'src/pipes/pipes.module';
 import { Bean } from 'src/classes/bean/bean';
 
 describe('BeanFreezeInformationComponent', () => {

--- a/src/components/beans/bean-freeze-information/bean-freeze-information.component.spec.ts
+++ b/src/components/beans/bean-freeze-information/bean-freeze-information.component.spec.ts
@@ -2,6 +2,12 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { BeanFreezeInformationComponent } from './bean-freeze-information.component';
+import { IonicStorageModule } from '@ionic/storage-angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { UIHelper } from 'src/services/uiHelper';
+import { UIHelperMock } from 'src/classes/mock';
+import { PipesModule } from 'src/pipes/PipesModule';
+import { Bean } from 'src/classes/bean/bean';
 
 describe('BeanFreezeInformationComponent', () => {
   let component: BeanFreezeInformationComponent;
@@ -10,13 +16,22 @@ describe('BeanFreezeInformationComponent', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [BeanFreezeInformationComponent],
-      imports: [IonicModule.forRoot()],
+      imports: [
+        IonicModule.forRoot(),
+        IonicStorageModule.forRoot(),
+        TranslateModule.forRoot(),
+        PipesModule,
+      ],
+      providers: [{ provide: UIHelper, useClass: UIHelperMock }],
     }).compileComponents();
+  }));
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(BeanFreezeInformationComponent);
     component = fixture.componentInstance;
+    component.data = new Bean();
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();

--- a/src/components/beans/bean-general-information/bean-general-information.component.spec.ts
+++ b/src/components/beans/bean-general-information/bean-general-information.component.spec.ts
@@ -8,8 +8,8 @@ import { UIHelper } from '../../../services/uiHelper';
 import { UIHelperMock } from '../../../classes/mock';
 import { Bean } from '../../../classes/bean/bean';
 import { FormsModule } from '@angular/forms';
-import { KeysPipe } from '../../../pipes/keys';
 import { Config } from '../../../classes/objectConfig/objectConfig';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BeanGeneralInformationComponent', () => {
   let component: BeanGeneralInformationComponent;
@@ -17,8 +17,13 @@ describe('BeanGeneralInformationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [BeanGeneralInformationComponent, KeysPipe],
-      imports: [IonicModule.forRoot(), TranslateModule.forRoot(), FormsModule],
+      declarations: [BeanGeneralInformationComponent],
+      imports: [
+        IonicModule.forRoot(),
+        TranslateModule.forRoot(),
+        FormsModule,
+        PipesModule,
+      ],
       providers: [
         { provide: Storage },
         { provide: UIHelper, useClass: UIHelperMock },

--- a/src/components/brew-graph-reference-card/brew-graph-reference-card.component.spec.ts
+++ b/src/components/brew-graph-reference-card/brew-graph-reference-card.component.spec.ts
@@ -7,11 +7,11 @@ import { TranslateModule } from '@ngx-translate/core';
 import { UIHelper } from '../../services/uiHelper';
 import { UIHelperMock } from '../../classes/mock';
 import { Brew } from '../../classes/brew/brew';
-import { FormatDatePipe } from '../../pipes/formatDate';
 import { IBrew } from '../../interfaces/brew/iBrew';
 import { Bean } from '../../classes/bean/bean';
 import { Preparation } from '../../classes/preparation/preparation';
 import { Mill } from '../../classes/mill/mill';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BrewGraphReferenceCardComponent', () => {
   let component: BrewGraphReferenceCardComponent;
@@ -19,8 +19,8 @@ describe('BrewGraphReferenceCardComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [BrewGraphReferenceCardComponent, FormatDatePipe],
-      imports: [IonicModule.forRoot(), TranslateModule.forRoot()],
+      declarations: [BrewGraphReferenceCardComponent],
+      imports: [IonicModule.forRoot(), TranslateModule.forRoot(), PipesModule],
       providers: [
         { provide: Storage },
         { provide: UIHelper, useClass: UIHelperMock },

--- a/src/components/brew-information/brew-information.component.spec.ts
+++ b/src/components/brew-information/brew-information.component.spec.ts
@@ -13,12 +13,12 @@ import { UIImage } from '../../services/uiImage';
 import { SocialSharing } from '@awesome-cordova-plugins/social-sharing/ngx';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FileTransfer } from '@awesome-cordova-plugins/file-transfer/ngx';
-import { FormatDatePipe } from '../../pipes/formatDate';
 import { Brew } from '../../classes/brew/brew';
 import { IBrew } from '../../interfaces/brew/iBrew';
 import { Bean } from '../../classes/bean/bean';
 import { Preparation } from '../../classes/preparation/preparation';
 import { Mill } from '../../classes/mill/mill';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BrewInformationComponent', () => {
   let component: BrewInformationComponent;
@@ -26,11 +26,12 @@ describe('BrewInformationComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      declarations: [BrewInformationComponent, FormatDatePipe],
+      declarations: [BrewInformationComponent],
       imports: [
         IonicModule.forRoot(),
         TranslateModule.forRoot(),
         HttpClientTestingModule,
+        PipesModule,
       ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
       providers: [

--- a/src/components/brew-timer/brew-timer.component.spec.ts
+++ b/src/components/brew-timer/brew-timer.component.spec.ts
@@ -6,6 +6,7 @@ import { ModalController } from '@ionic/angular';
 import { CoffeeBluetoothDevicesService } from '../../services/coffeeBluetoothDevices/coffee-bluetooth-devices.service';
 import { UISettingsStorage } from '../../services/uiSettingsStorage';
 import { Settings } from '../../classes/settings/settings';
+import { Device } from '@awesome-cordova-plugins/device/ngx';
 
 describe('BrewTimerComponent', () => {
   let component: BrewTimerComponent;
@@ -31,6 +32,9 @@ describe('BrewTimerComponent', () => {
               return {} as unknown as Settings;
             },
           },
+        },
+        {
+          provide: Device,
         },
       ],
     }).compileComponents();

--- a/src/components/brews/brew-brewing-graph/brew-brewing-graph.component.ts
+++ b/src/components/brews/brew-brewing-graph/brew-brewing-graph.component.ts
@@ -2941,7 +2941,7 @@ export class BrewBrewingGraphComponent implements OnInit {
     this.stopFetchingAndSettingDataFromXenia();
     this.stopFetchingDataFromMeticulous();
 
-    if (this.settings.text_to_speech_active) {
+    if (this.settings?.text_to_speech_active) {
       this.textToSpeech.end();
     }
   }

--- a/src/components/brews/brew-brewing/brew-brewing.component.spec.ts
+++ b/src/components/brews/brew-brewing/brew-brewing.component.spec.ts
@@ -13,8 +13,8 @@ import { ScreenOrientation } from '@awesome-cordova-plugins/screen-orientation/n
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { BrewBrewingGraphComponent } from '../brew-brewing-graph/brew-brewing-graph.component';
 import { FormsModule } from '@angular/forms';
-import { KeysPipe } from 'src/pipes/keys';
 import { BrewBrewingPreparationDeviceComponent } from '../brew-brewing-preparation-device/brew-brewing-preparation-device.component';
+import { PipesModule } from 'src/pipes/pipes.module';
 
 describe('BrewBrewingComponent', () => {
   let component: BrewBrewingComponent;
@@ -26,13 +26,13 @@ describe('BrewBrewingComponent', () => {
         BrewBrewingComponent,
         BrewBrewingGraphComponent,
         BrewBrewingPreparationDeviceComponent,
-        KeysPipe,
       ],
       imports: [
         IonicModule.forRoot(),
         TranslateModule.forRoot(),
         HttpClientTestingModule,
         FormsModule,
+        PipesModule,
       ],
       providers: [
         { provide: Storage },

--- a/src/components/timer/timer.component.spec.ts
+++ b/src/components/timer/timer.component.spec.ts
@@ -6,6 +6,7 @@ import { ModalController } from '@ionic/angular';
 import { CoffeeBluetoothDevicesService } from '../../services/coffeeBluetoothDevices/coffee-bluetooth-devices.service';
 import { UISettingsStorage } from '../../services/uiSettingsStorage';
 import { Settings } from '../../classes/settings/settings';
+import { Device } from '@awesome-cordova-plugins/device/ngx';
 
 describe('TimerComponent', () => {
   let component: TimerComponent;
@@ -31,6 +32,9 @@ describe('TimerComponent', () => {
               return {} as unknown as Settings;
             },
           },
+        },
+        {
+          provide: Device,
         },
       ],
     }).compileComponents();

--- a/src/pipes/pipes.module.ts
+++ b/src/pipes/pipes.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { KeysPipe } from './keys';
+import { EnumToArrayPipe } from './enumToArray';
+import { FormatDatePipe } from './formatDate';
+
+@NgModule({
+  declarations: [EnumToArrayPipe, FormatDatePipe, KeysPipe],
+  exports: [EnumToArrayPipe, FormatDatePipe, KeysPipe],
+})
+export class PipesModule {}

--- a/src/popover/meticulous-help-popover/meticulous-help-popover.component.spec.ts
+++ b/src/popover/meticulous-help-popover/meticulous-help-popover.component.spec.ts
@@ -2,21 +2,33 @@ import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { IonicModule } from '@ionic/angular';
 
 import { MeticulousHelpPopoverComponent } from './meticulous-help-popover.component';
+import { IonicStorageModule } from '@ionic/storage-angular';
+import { TranslateModule } from '@ngx-translate/core';
+import { UIHelper } from 'src/services/uiHelper';
+import { UIHelperMock } from 'src/classes/mock';
 
-describe('MeticulousHelpPopoverComponent', () => {
+describe('', () => {
   let component: MeticulousHelpPopoverComponent;
   let fixture: ComponentFixture<MeticulousHelpPopoverComponent>;
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       declarations: [MeticulousHelpPopoverComponent],
-      imports: [IonicModule.forRoot()],
+      imports: [
+        IonicModule.forRoot(),
+        IonicStorageModule.forRoot(),
+        // TranslateModule.forChild(),
+        TranslateModule.forRoot(),
+      ],
+      providers: [{ provide: UIHelper, useClass: UIHelperMock }],
     }).compileComponents();
+  }));
 
+  beforeEach(() => {
     fixture = TestBed.createComponent(MeticulousHelpPopoverComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
-  }));
+  });
 
   it('should create', () => {
     expect(component).toBeTruthy();


### PR DESCRIPTION
* Fix tests added or broken by the latest changes in `develop`.
* Create `PipesModule` to import pipes without having to import `SharedModule`. Import it in all test modules instead of declaring `XPipe` classes.
* Fix test flakiness (random tests would fail in different runs) caused by an error in `BrewBrewingGraphComponent.destroy` during tests when `this.settings` was not initialised.

Resolves #730.
Once this is merged, the tests should be in a good enough state to submit the GitHub Action to run tests automatically for #740.