### PR TITLE
Use UUID-based attachment file names and improve attachment caching

### DIFF
--- a/src/app/beans/bean-popover-freeze/bean-popover-freeze.component.ts
+++ b/src/app/beans/bean-popover-freeze/bean-popover-freeze.component.ts
@@ -115,7 +115,7 @@ export class BeanPopoverFreezeComponent implements OnInit {
       totalGreenBeanWeight = this.bean.bean_roast_information.green_bean_weight;
     }
 
-    let groupBeanId = this.uiHelper.generateUUID();
+    let groupBeanId: string = crypto.randomUUID();
     if (this.bean.frozenGroupId) {
       //If we froze the initial bean already, we use this as the reference again.
       groupBeanId = this.bean.frozenGroupId;

--- a/src/classes/storageClass.ts
+++ b/src/classes/storageClass.ts
@@ -72,7 +72,7 @@ export abstract class StorageClass {
     const promise = new Promise(async (resolve, reject) => {
       const newEntry = this.uiHelper.cloneData(_entry);
       try {
-        newEntry.config.uuid = this.uiHelper.generateUUID();
+        newEntry.config.uuid = crypto.randomUUID();
         newEntry.config.unix_timestamp = this.uiHelper.getUnixTimestamp();
         this.storedData.push(newEntry);
         await this.__save();

--- a/src/components/async-image/async-image.component.html
+++ b/src/components/async-image/async-image.component.html
@@ -1,2 +1,4 @@
-<img (error)="onError()" *ngIf="img !== '' && errorOccured === false" [src]="img" alt="Async error image"/>
-<img *ngIf="img==='' && errorOccured === false" [src]="preloadImg" alt="Preload image" class="preload-img"/>
+<!-- If we wanted a reasonable alt-text, it would have to be set by the user of this component -->
+<!-- eslint-disable-next-line @angular-eslint/template/alt-text -->
+<img *ngIf="!isLoading && !errorOccured && (img | async)" [src]="img | async"/>
+<img *ngIf="isLoading && showLoadingImage" [src]="preloadImg" alt="Image is loading" class="preload-img"/>

--- a/src/components/async-image/async-image.component.ts
+++ b/src/components/async-image/async-image.component.ts
@@ -39,10 +39,7 @@ export class AsyncImageComponent implements OnInit, OnChanges {
       if (this.filePath.startsWith('http')) {
         this.img = this.filePath;
       } else {
-        this.img = await this.uiFileHelper.getInternalFileSrc(
-          this.filePath,
-          true
-        );
+        this.img = await this.uiFileHelper.getInternalFileSrc(this.filePath);
       }
     }
     if (this.img === '') {

--- a/src/components/async-image/async-image.component.ts
+++ b/src/components/async-image/async-image.component.ts
@@ -1,5 +1,5 @@
-import {Component, Input, OnChanges, OnInit} from '@angular/core';
-import {UIFileHelper} from '../../services/uiFileHelper';
+import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { UIFileHelper } from '../../services/uiFileHelper';
 
 @Component({
   selector: 'async-image',
@@ -9,11 +9,10 @@ import {UIFileHelper} from '../../services/uiFileHelper';
 export class AsyncImageComponent implements OnInit, OnChanges {
   @Input() public filePath: string;
 
-
-  public errorOccured:boolean = false;
+  public errorOccured: boolean = false;
   public img: string = '';
   public preloadImg: string = 'assets/img/loading.gif';
-  constructor( private uiFileHelper: UIFileHelper) { }
+  constructor(private uiFileHelper: UIFileHelper) {}
 
   public async ngOnInit(): Promise<void> {
     await this.__checkImageChanges();
@@ -28,18 +27,21 @@ export class AsyncImageComponent implements OnInit, OnChanges {
   }
 
   private async __checkImageChanges(): Promise<void> {
-
-    if (this.filePath === undefined || this.filePath === null || this.filePath === '') {
+    if (
+      this.filePath === undefined ||
+      this.filePath === null ||
+      this.filePath === ''
+    ) {
       this.img = '';
     } else {
       if (this.filePath.startsWith('http')) {
         this.img = this.filePath;
       } else {
-
-        this.img = await this.uiFileHelper.getInternalFileSrc(this.filePath,true);
-
+        this.img = await this.uiFileHelper.getInternalFileSrc(
+          this.filePath,
+          true
+        );
       }
-
     }
     if (this.img === '') {
       this.errorOccured = true;
@@ -47,5 +49,4 @@ export class AsyncImageComponent implements OnInit, OnChanges {
       this.errorOccured = false;
     }
   }
-
 }

--- a/src/components/async-image/async-image.component.ts
+++ b/src/components/async-image/async-image.component.ts
@@ -9,17 +9,19 @@ import { UIFileHelper } from '../../services/uiFileHelper';
 export class AsyncImageComponent implements OnInit, OnChanges {
   @Input() public filePath: string;
 
-  public errorOccured: boolean = false;
-  public img: string = '';
-  public preloadImg: string = 'assets/img/loading.gif';
+  public errorOccured = false;
+  public img = '';
+  public preloadImg = 'assets/img/loading.gif';
   constructor(private uiFileHelper: UIFileHelper) {}
 
-  public async ngOnInit(): Promise<void> {
-    await this.__checkImageChanges();
+  public ngOnInit(): void {
+    // ngOnInit does not support Promise return types, can't await
+    void this.__checkImageChanges();
   }
 
-  public async ngOnChanges(): Promise<void> {
-    await this.__checkImageChanges();
+  public ngOnChanges(): void {
+    // ngOnChanges does not support Promise return types, can't await
+    void this.__checkImageChanges();
   }
 
   public onError() {

--- a/src/components/async-image/async-image.component.ts
+++ b/src/components/async-image/async-image.component.ts
@@ -1,51 +1,48 @@
-import { Component, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, Input, OnChanges } from '@angular/core';
 import { UIFileHelper } from '../../services/uiFileHelper';
+import { SafeResourceUrl } from '@angular/platform-browser';
 
 @Component({
   selector: 'async-image',
   templateUrl: './async-image.component.html',
   styleUrls: ['./async-image.component.scss'],
 })
-export class AsyncImageComponent implements OnInit, OnChanges {
+export class AsyncImageComponent implements OnChanges {
   @Input() public filePath: string;
+  @Input() public showLoadingImage = false;
 
   public errorOccured = false;
-  public img = '';
+  public isLoading = false;
+  public img: Promise<SafeResourceUrl | undefined> = Promise.resolve(undefined);
   public preloadImg = 'assets/img/loading.gif';
   constructor(private uiFileHelper: UIFileHelper) {}
 
-  public ngOnInit(): void {
-    // ngOnInit does not support Promise return types, can't await
-    void this.__checkImageChanges();
-  }
-
   public ngOnChanges(): void {
-    // ngOnChanges does not support Promise return types, can't await
-    void this.__checkImageChanges();
+    this.img = this.getImageSrc();
   }
 
-  public onError() {
-    this.img = '';
-  }
-
-  private async __checkImageChanges(): Promise<void> {
+  private async getImageSrc(): Promise<SafeResourceUrl | undefined> {
     if (
       this.filePath === undefined ||
       this.filePath === null ||
       this.filePath === ''
     ) {
-      this.img = '';
-    } else {
-      if (this.filePath.startsWith('http')) {
-        this.img = this.filePath;
-      } else {
-        this.img = await this.uiFileHelper.getInternalFileSrc(this.filePath);
-      }
+      return undefined;
     }
-    if (this.img === '') {
-      this.errorOccured = true;
-    } else {
+
+    if (this.filePath.startsWith('http')) {
+      return this.filePath;
+    }
+
+    try {
+      this.isLoading = true;
+      const src = await this.uiFileHelper.getInternalFileSrc(this.filePath);
       this.errorOccured = false;
+      return src;
+    } catch (error) {
+      this.errorOccured = true;
+    } finally {
+      this.isLoading = false;
     }
   }
 }

--- a/src/services/uiFileHelper.ts
+++ b/src/services/uiFileHelper.ts
@@ -657,15 +657,12 @@ export class UIFileHelper extends InstanceClass {
     }
   }
 
-  public async getInternalFileSrc(
-    _filePath: string,
-    _addTimeStamp = false
-  ): Promise<any> {
+  public async getInternalFileSrc(filePath: string): Promise<any> {
     if (!this.platform.is('capacitor')) {
       return '';
     }
     try {
-      let fileName = this.normalizeFileName(_filePath);
+      let fileName = this.normalizeFileName(filePath);
 
       if (this.platform.is('ios')) {
         // After switching to iOS cloud, the fullPath saves the Cloud path actualy with, so we need to delete this one :)
@@ -682,15 +679,12 @@ export class UIFileHelper extends InstanceClass {
       // Check if file exists; stat() will throw if it does not exist
       await Filesystem.stat(fileOptions);
       const { uri } = await Filesystem.getUri(fileOptions);
-      let fileSrcUri = Capacitor.convertFileSrc(uri);
-      if (_addTimeStamp) {
-        fileSrcUri += '?' + moment().unix();
-      }
+      const fileSrcUri = Capacitor.convertFileSrc(uri);
       return this.domSanitizer.bypassSecurityTrustResourceUrl(fileSrcUri);
     } catch (error) {
       this.uiLog.error(
         'Error in getInternalFileSrc for path',
-        _filePath,
+        filePath,
         ':',
         error
       );

--- a/src/services/uiFileHelper.ts
+++ b/src/services/uiFileHelper.ts
@@ -8,7 +8,7 @@ import {
   StatOptions,
 } from '@capacitor/filesystem';
 import { Platform } from '@ionic/angular';
-import { DomSanitizer } from '@angular/platform-browser';
+import { DomSanitizer, SafeResourceUrl } from '@angular/platform-browser';
 import { UILog } from './uiLog';
 
 import moment from 'moment';
@@ -657,7 +657,7 @@ export class UIFileHelper extends InstanceClass {
     }
   }
 
-  public async getInternalFileSrc(filePath: string): Promise<any> {
+  public async getInternalFileSrc(filePath: string): Promise<SafeResourceUrl> {
     if (!this.platform.is('capacitor')) {
       return '';
     }

--- a/src/services/uiFileHelper.ts
+++ b/src/services/uiFileHelper.ts
@@ -688,7 +688,8 @@ export class UIFileHelper extends InstanceClass {
         ':',
         error
       );
-      return '';
+      // still reject after logging
+      throw error;
     }
   }
 

--- a/src/services/uiHelper.ts
+++ b/src/services/uiHelper.ts
@@ -111,17 +111,6 @@ export class UIHelper {
     });
   }
 
-  public generateUUID(): string {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-      const r =
-          ((crypto.getRandomValues(new Uint8Array(1))[0] / Math.pow(2, 8)) *
-            16) |
-          0,
-        v = c === 'x' ? r : (r & 0x3) | 0x8;
-      return v.toString(16);
-    });
-  }
-
   public showAlert(_message, _title?: string) {
     this.uiAlert.showMessage(_message, _title);
   }

--- a/src/services/uiImage.ts
+++ b/src/services/uiImage.ts
@@ -49,7 +49,7 @@ export class UIImage {
 
   private async saveBase64Photo(base64: string): Promise<string> {
     const fileName = await this.uiFileHelper.generateInternalPath(
-      'beanconqueror_image',
+      'photo',
       '.jpg'
     );
     const fileUri = await this.uiFileHelper.writeInternalFileFromBase64(


### PR DESCRIPTION
To solve #833, the file names for attachments such as images now use UUIDv4-based names. This prevents re-using file names of old deleted images that are still referenced in the database.

Doing that also allows us to drop the cache buster parameter when displaying attachment images. This allows the browser to use its cache for attachment images. While I did that I also cleaned up the `<async-image>` implementation a bit. All in all, this makes image loading noticeably faster and smoother on my phone.

I also disabled the placeholder image in `<async-image>` by default. To me, the flicker that is introduced by first showing the loading placeholder for 100ms-200ms is much worse than just having the image pop in after the loading time without warning. It is also important to note that the loading image is only shown while the URL for the image is still loading. A blank space is shown while the image is loaded from that URL anyway.
But if for some reason we deem it necessary to have the placeholder, it can be easily enabled again by changing the value of `showLoadingImage`.

