### PR TITLE
Revert "Work around dependency version bug in capacitor-barcode-scanner"

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,21 +44,6 @@ dependencies {
     androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
     androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
     implementation project(':capacitor-cordova-android-plugins')
-
-    constraints {
-      // Work around https://github.com/ionic-team/capacitor-barcode-scanner/pull/40
-      // and https://github.com/ionic-team/capacitor-barcode-scanner/issues/41
-      // to make barcode scanner work. Remove this once the upstream issues are resolved.
-      implementation('androidx.camera:camera-camera2:1.4.0') {
-        because 'capacitor-barcode-scanner pulls in the wrong version. See https://github.com/ionic-team/capacitor-barcode-scanner/pull/40 and https://github.com/ionic-team/capacitor-barcode-scanner/issues/41'
-      }
-      implementation('androidx.camera:camera-lifecycle:1.4.0') {
-        because 'capacitor-barcode-scanner pulls in the wrong version. See https://github.com/ionic-team/capacitor-barcode-scanner/pull/40 and https://github.com/ionic-team/capacitor-barcode-scanner/issues/41'
-      }
-      implementation('androidx.camera:camera-view:1.4.0') {
-        because 'capacitor-barcode-scanner pulls in the wrong version. See https://github.com/ionic-team/capacitor-barcode-scanner/pull/40 and https://github.com/ionic-team/capacitor-barcode-scanner/issues/41'
-      }
-    }
 }
 
 apply from: 'capacitor.build.gradle'


### PR DESCRIPTION
The issue was fixed upstream in the barcode scanner. With the update to version 1.0.4, (see ccf956fa169b09e79768e25de9dca79e232ccdad) this hack is no longer required and would cause runtime issues if the barcode scanner ever updates its dependencies in the future.

This reverts commit 80e0a96674031c49cc800879c25b684b0a76ae36.

See #846 