### PR TITLE
Log the WebView version on startup

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -294,6 +294,7 @@ export class AppComponent implements AfterViewInit {
         this.uiLog.log(`Manufacturer: ${deviceInfo.manufacturer}`);
         this.uiLog.log(`Platform: ${deviceInfo.platform}`);
         this.uiLog.log(`Version: ${deviceInfo.osVersion}`);
+        this.uiLog.log(`WebView version: ${deviceInfo.webViewVersion}`);
         if (this.platform.is('capacitor')) {
           const versionCode = (await App.getInfo()).version;
           this.uiLog.log(`App-Version: ${versionCode}`);


### PR DESCRIPTION
This also works in native browsers (where it will just log the browser version) so there is no need to disable the log entry when not running under Capacitor.

This might help with debugging weird browser API issues like #866.