### PR TITLE
Automatic Rating Calculation for Beans

### DIFF
--- a/src/app/beans/bean-archive-popover/bean-archive-popover.component.html
+++ b/src/app/beans/bean-archive-popover/bean-archive-popover.component.html
@@ -7,10 +7,10 @@
       <h3>{{data.name}}</h3>
     </ion-label>
   </ion-item>
-  <ion-item *ngIf="brewsWithRatings().length > 0 && data.rating > 0">
+  <ion-item *ngIf="averageBrewRating !== undefined">
     <ion-label>
       <h2>{{"BEAN_DATA_AVERAGE_BREW_RATING" | translate}}</h2>
-      <h3>{{calculateAverageBeanRating()}}</h3>
+      <h3>{{averageBrewRating}}</h3>
     </ion-label>
   </ion-item>
   <ion-item>

--- a/src/app/beans/bean-archive-popover/bean-archive-popover.component.html
+++ b/src/app/beans/bean-archive-popover/bean-archive-popover.component.html
@@ -7,6 +7,12 @@
       <h3>{{data.name}}</h3>
     </ion-label>
   </ion-item>
+  <ion-item *ngIf="brewsWithRatings().length > 0 && data.rating > 0">
+    <ion-label>
+      <h2>{{"BEAN_DATA_AVERAGE_BREW_RATING" | translate}}</h2>
+      <h3>{{calculateAverageBeanRating()}}</h3>
+    </ion-label>
+  </ion-item>
   <ion-item>
     <ion-label position="stacked" style="min-height:30px;">{{"BREW_DATA_RATING" | translate }}&nbsp;<ion-badge
       style="vertical-align: top;">{{data.rating | toFixed: 2}}</ion-badge>

--- a/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
+++ b/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
@@ -100,20 +100,6 @@ export class BeanArchivePopoverComponent implements OnInit {
     );
     const roundedRating = numberOfSteps * this.settings.bean_rating_steps;
 
-    // In certain scenarios floating point arithmetic in JS can lead to unexpected results.
-    // For example if numberOfSteps = 12 and rating_steps = .1 then the result will be
-    // 12 * .1 = 1.2000000000000002. To avoid this we truncate the result based on the number of decimals in the rating_steps.
-    const numberOfDecimals = this.numberOfDecimalsToTruncate(
-      this.settings.bean_rating_steps,
-    );
-    return parseFloat(roundedRating.toFixed(numberOfDecimals));
-  }
-
-  private numberOfDecimalsToTruncate(rating_steps: number): number {
-    const rating_steps_str = rating_steps.toString();
-    if (rating_steps_str.indexOf('.') === -1) {
-      return 0;
-    }
-    return rating_steps_str.split('.')[1].length;
+    return this.uiHelper.toFixedIfNecessary(roundedRating, 2);
   }
 }

--- a/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
+++ b/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
@@ -98,6 +98,22 @@ export class BeanArchivePopoverComponent implements OnInit {
     const numberOfSteps = Math.round(
       averageRating / this.settings.bean_rating_steps,
     );
-    return numberOfSteps * this.settings.bean_rating_steps;
+    const roundedRating = numberOfSteps * this.settings.bean_rating_steps;
+
+    // In certain scenarios floating point arithmetic in JS can lead to unexpected results.
+    // For example if numberOfSteps = 12 and rating_steps = .1 then the result will be
+    // 12 * .1 = 1.2000000000000002. To avoid this we truncate the result based on the number of decimals in the rating_steps.
+    const numberOfDecimals = this.numberOfDecimalsToTruncate(
+      this.settings.bean_rating_steps,
+    );
+    return parseFloat(roundedRating.toFixed(numberOfDecimals));
+  }
+
+  private numberOfDecimalsToTruncate(rating_steps: number): number {
+    const rating_steps_str = rating_steps.toString();
+    if (rating_steps_str.indexOf('.') === -1) {
+      return 0;
+    }
+    return rating_steps_str.split('.')[1].length;
   }
 }

--- a/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
+++ b/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
@@ -8,6 +8,7 @@ import { NgxStarsComponent } from 'ngx-stars';
 import { Settings } from '../../../classes/settings/settings';
 import { UISettingsStorage } from '../../../services/uiSettingsStorage';
 import { UIHelper } from '../../../services/uiHelper';
+import { Brew } from '../../../classes/brew/brew';
 
 @Component({
   selector: 'app-bean-archive-popover',
@@ -28,7 +29,7 @@ export class BeanArchivePopoverComponent implements OnInit {
     private readonly modalController: ModalController,
     private readonly uiToast: UIToast,
     private readonly uiSettingsStorage: UISettingsStorage,
-    public readonly uiHelper: UIHelper
+    public readonly uiHelper: UIHelper,
   ) {
     this.settings = this.uiSettingsStorage.getSettings();
     this.maxBeanRating = this.settings.bean_rating;
@@ -38,6 +39,8 @@ export class BeanArchivePopoverComponent implements OnInit {
   public ionViewWillEnter(): void {
     if (this.bean !== undefined) {
       this.data.initializeByObject(this.bean);
+      if (this.data.rating === 0)
+        this.data.rating = this.calculateAverageBeanRating();
       if (this.data.rating > 0) {
         this.changedRating();
       }
@@ -57,12 +60,26 @@ export class BeanArchivePopoverComponent implements OnInit {
         dismissed: true,
       },
       undefined,
-      BeanArchivePopoverComponent.COMPONENT_ID
+      BeanArchivePopoverComponent.COMPONENT_ID,
     );
   }
   public changedRating() {
     if (typeof this.beanRating !== 'undefined') {
       this.beanRating.setRating(this.data.rating);
     }
+  }
+
+  public calculateAverageBeanRating(): number {
+    let sum = 0;
+    const brewsWithRatings = this.brewsWithRatings();
+    const ratio = this.settings.bean_rating / this.settings.brew_rating;
+    brewsWithRatings.forEach((currentBrew, _index, _arr) => {
+      sum += currentBrew.rating * ratio;
+    });
+    return Math.round(sum / brewsWithRatings.length);
+  }
+
+  public brewsWithRatings(): Brew[] {
+    return this.data.getBrews().filter((brew) => brew.rating > 0);
   }
 }

--- a/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
+++ b/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
@@ -21,6 +21,7 @@ export class BeanArchivePopoverComponent implements OnInit {
   @ViewChild('beanRating', { read: NgxStarsComponent, static: false })
   public beanRating: NgxStarsComponent;
   public data: Bean = new Bean();
+  public calculateAverageBrewRating: number;
 
   public maxBeanRating: number = 5;
   public settings: Settings = undefined;
@@ -76,7 +77,11 @@ export class BeanArchivePopoverComponent implements OnInit {
     brewsWithRatings.forEach((currentBrew, _index, _arr) => {
       sum += currentBrew.rating * ratio;
     });
-    return Math.round(sum / brewsWithRatings.length);
+    const averageRating = sum / brewsWithRatings.length;
+    const numberOfSteps = Math.round(
+      averageRating / this.settings.bean_rating_steps,
+    );
+    return numberOfSteps * this.settings.bean_rating_steps;
   }
 
   public brewsWithRatings(): Brew[] {

--- a/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
+++ b/src/app/beans/bean-archive-popover/bean-archive-popover.component.ts
@@ -47,7 +47,6 @@ export class BeanArchivePopoverComponent implements OnInit {
       if (this.data.rating > 0) {
         this.changedRating();
       }
-      console.log('this.data.rating = ', this.data.rating);
     }
   }
 
@@ -74,12 +73,15 @@ export class BeanArchivePopoverComponent implements OnInit {
   }
 
   private tryCalcuatingAverageBrewRating() {
+    // An existing rating on the bean exists. Don't attempt to calculate average rating.
     if (this.data.rating !== 0) {
       return;
     }
+
     const brewsWithRatings = this.data
       .getBrews()
       .filter((brew) => brew.rating > 0);
+    // No brews with ratings found. Don't attempt to calculate average rating.
     if (brewsWithRatings.length === 0) {
       return;
     }

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -109,6 +109,7 @@
     "BEAN_DATA_PURCHASING_PRICE": "Purchase price",
     "BEAN_DATA_FOB_PRICE": "FOB price",
     "BEAN_DATA_CUPPING_POINTS": "Cupping points",
+    "BEAN_DATA_AVERAGE_BREW_RATING": "Average Brew Rating",
     "BREW_DATA_CUSTOM_BREW_TIME": "Custom brewing time",
     "BREW_CREATION_DATE": "Creation Date",
     "REPEAT": "Repeat",

--- a/src/classes/bean/bean.ts
+++ b/src/classes/bean/bean.ts
@@ -366,4 +366,9 @@ export class Bean implements IBean {
   public hasPhotos() {
     return this.attachments && this.attachments.length > 0;
   }
+
+  public getBrews(): Brew[] {
+    const beanHelper: UIBeanHelper = UIBeanHelper.getInstance();
+    return beanHelper.getAllBrewsForThisBean(this.config.uuid);
+  }
 }


### PR DESCRIPTION
### What This PR Does

Implements an automatic rating calculation for beans as per #915 

### How This PR Was Tested

- [x] Averages correctly when brew and bean rating range are the same
- [x] Averages correctly when brew rating range is greater than bean rating range
- [x] Averages correctly when brew rating range is less than bean rating range
- [x] When there are no brew ratings the average brew number does not show and rating is set to current bean rating
- [x] When a bean rating already exists average bean rating is not calculated
- [x] When average is not an integer rounding works properly
- [x] Update steps and confirm correct average being calculated