### PR TITLE
fix: bokooScale timer reset checksum

### DIFF
--- a/src/classes/devices/bokooScale.ts
+++ b/src/classes/devices/bokooScale.ts
@@ -72,7 +72,7 @@ export class BookooScale extends BluetoothScale {
     } else if (_timer === SCALE_TIMER_COMMAND.STOP) {
       await this.write(new Uint8Array([0x03, 0x0a, 0x05, 0x00, 0x00, 0x0d]));
     } else if (_timer === SCALE_TIMER_COMMAND.RESET) {
-      await this.write(new Uint8Array([0x03, 0x0a, 0x06, 0x00, 0x00, 0x0d]));
+      await this.write(new Uint8Array([0x03, 0x0a, 0x06, 0x00, 0x00, 0x0c]));
     }
   }
 


### PR DESCRIPTION
Fix checksum to match https://github.com/BooKooCode/OpenSource/blob/main/bookoo_mini_scale/protocols.md

This is a cosmetic change because the scale seems to accept any checksum, but at least it is in line with the documentation.  I have a feeling the documentation is wrong as well because the checksums there don’t match the xor results of the commands.