### PR TITLE
Argos support, multi-source temperature devices

### DIFF
--- a/src/app/brew/brew-flow/brew-flow.component.ts
+++ b/src/app/brew/brew-flow/brew-flow.component.ts
@@ -484,7 +484,8 @@ export class BrewFlowComponent implements OnDestroy, OnInit {
     this.ngZone.runOutsideAngular(() => {
       if (this.temperatureDetail?.nativeElement) {
         const temperatureEl = this.temperatureDetail.nativeElement;
-        temperatureEl.textContent = _val.temperature;
+        const temperatureFormatted = _val.temperature.toFixed(2);
+        temperatureEl.textContent = temperatureFormatted;
       }
     });
   }

--- a/src/app/settings/settings.page.html
+++ b/src/app/settings/settings.page.html
@@ -1678,7 +1678,13 @@
             </div>
           </ion-checkbox>
         </ion-item>
-
+            <ion-item>
+              <ion-checkbox label-placement='start' (ngModelChange)="saveSettings();" [(ngModel)]="settings.temperature_show_before_timer">
+                <div class='ion-label' style="white-space: normal;">
+                  <h2>{{"TEMPERATURE.SHOW_BEFORE_TIMER" | translate}}</h2>
+                </div>
+              </ion-checkbox>
+        </ion-item>
       </ion-list>
 
       <ion-label>
@@ -1686,7 +1692,6 @@
         <p style="display: inline;">{{ "TEMPERATURE.INFORMATION_DESCRIPTION" | translate }}</p>
       </ion-label>
     </ion-card-content>
-
   </ion-card>
   }
   @case ('bluetoothrefractometer') {

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -125,6 +125,7 @@ import { UIUpdate } from '../../services/uiUpdate';
 import { UiVersionStorage } from '../../services/uiVersionStorage';
 import { UIWaterStorage } from '../../services/uiWaterStorage';
 import { VisualizerService } from '../../services/visualizerService/visualizer-service.service';
+import { TemperatureSource } from 'src/classes/devices/temperatureBluetoothDevice';
 
 @Component({
   selector: 'settings',
@@ -385,6 +386,7 @@ export class SettingsPage {
       if (disconnected) {
         this.settings.temperature_id = '';
         this.settings.temperature_type = null;
+        this.settings.temperature_graph_source = TemperatureSource.WATER_PROBE;
       }
     } else if (_type === BluetoothTypes.TDS) {
       this.eventQueue.dispatch(

--- a/src/assets/i18n/ar.json
+++ b/src/assets/i18n/ar.json
@@ -1535,7 +1535,8 @@
         },
         "LOG": "",
         "THRESHOLD_ACTIVE": "",
-        "THRESHOLD_TEMP": ""
+        "THRESHOLD_TEMP": "",
+        "SHOW_BEFORE_TIMER": ""
     },
     "POPOVER_BLUETOOTH_ACTION_RECONNECT_TEMPERATURE_DEVICE": "",
     "PRESSURE_DEVICE_JUST_VISIBLE_ON_ESPRESSO": "",

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1187,7 +1187,8 @@
         },
         "LOG": "Activate log files for temperature device",
         "THRESHOLD_ACTIVE": "Start timer with predefined temperature",
-        "THRESHOLD_TEMP": "Threshold temperature"
+        "THRESHOLD_TEMP": "Threshold temperature",
+        "SHOW_BEFORE_TIMER": "Show temperature before timer starts"
     },
     "POPOVER_BLUETOOTH_ACTION_RECONNECT_TEMPERATURE_DEVICE": "Reconnect temperature device",
     "PRESSURE_DEVICE_JUST_VISIBLE_ON_ESPRESSO": "Pressure device is only usable with the preparation style 'Espresso'",

--- a/src/classes/brew/brewFlow.ts
+++ b/src/classes/brew/brewFlow.ts
@@ -8,6 +8,8 @@ export class BrewFlow {
   public temperatureFlow: Array<IBrewTemperatureFlow>;
   public waterDispensed: Array<IBrewWaterDispensedFlow>;
   public waterDispensedFlowSecond: Array<IBrewWaterDispensedFlow>;
+  public basketTemperatureFlow: Array<IBrewTemperatureFlow>;
+  public targetTemperatureFlow: Array<IBrewTemperatureFlow>;
   public brewbyweight: Array<IBrewByWeight>;
   public customMetrics: { [key: string]: Array<IBrewCustomMetric> };
   public customAxes: Array<IBrewCustomAxis>;
@@ -22,6 +24,8 @@ export class BrewFlow {
     this.temperatureFlow = [];
     this.waterDispensed = [];
     this.waterDispensedFlowSecond = [];
+    this.basketTemperatureFlow = [];
+    this.targetTemperatureFlow = [];
     this.brewbyweight = [];
     this.customMetrics = {};
     this.customAxes = [];

--- a/src/classes/devices/argosThermometer.ts
+++ b/src/classes/devices/argosThermometer.ts
@@ -1,21 +1,44 @@
 import { PeripheralData } from './ble.types';
 import { Logger } from './common/logger';
-import { TemperatureDevice } from './temperatureBluetoothDevice';
+import {
+  TemperatureDevice,
+  TemperatureSource,
+} from './temperatureBluetoothDevice';
 
 declare var ble: any;
 
 export class ArgosThermometer extends TemperatureDevice {
   public static DEVICE_NAME = 'ARGOS';
+
+  // Should Argos be a seperate preperationDevice, so we can track all these?
+  // - setpoint would be handy to set on the shot as it doesn't change
+  // - group head & boiler could be tracked in graphs
+  // - how would these line up to Visualizer fields of target temp goal, temp basket, temp mix etc
   public static TEMPERATURE_SERVICE_UUID =
     '6a521c59-55b5-4384-85c0-6534e63fb09e';
-  public static TEMPERATURE_CHAR_UUID = '6a521c62-55b5-4384-85c0-6534e63fb09e';
+  public static TEMPERATURE_SETPOINT_CHAR_UUID =
+    '6a521c60-55b5-4384-85c0-6534e63fb09e';
+  public static TEMPERATURE_GROUPHEAD_CHAR_UUID =
+    '6a521c62-55b5-4384-85c0-6534e63fb09e';
+  public static TEMPERATURE_BOILER_CURRENT_CHAR_UUID =
+    '6a521c61-55b5-4384-85c0-6534e63fb09e';
+  public static TEMPERATURE_BOILER_TARGET_CHAR_UUID =
+    '6a521c66-55b5-4384-85c0-6534e63fb09e';
 
   private logger: Logger;
+  private state: {
+    setPoint: number;
+    boilerTarget: number;
+  };
 
   constructor(data: PeripheralData) {
-    super(data);
+    super(data, TemperatureSource.SET_POINT);
     this.connect();
     this.logger = new Logger('ArgosTemperatureSensor');
+    this.state = {
+      setPoint: 0,
+      boilerTarget: 0,
+    };
   }
 
   public static test(device: any): boolean {
@@ -37,40 +60,106 @@ export class ArgosThermometer extends TemperatureDevice {
   }
 
   private attachNotification() {
+    this.attachArgosNotification(
+      ArgosThermometer.TEMPERATURE_SETPOINT_CHAR_UUID,
+    );
+    this.attachArgosNotification(
+      ArgosThermometer.TEMPERATURE_BOILER_CURRENT_CHAR_UUID,
+    );
+    this.attachArgosNotification(
+      ArgosThermometer.TEMPERATURE_BOILER_TARGET_CHAR_UUID,
+    );
+  }
+
+  private attachArgosNotification(characteristic: string) {
     ble.startNotification(
       this.device_id,
       ArgosThermometer.TEMPERATURE_SERVICE_UUID,
-      ArgosThermometer.TEMPERATURE_CHAR_UUID,
+      characteristic,
 
       async (_data: any) => {
-        const rawData = _data; //new Uint8Array(_data.slice(0, -1));
-        this.parseStatusUpdate(rawData);
+        this.parseStatusUpdate(_data, characteristic);
       },
 
       (_data: any) => {},
     );
   }
 
-  private parseStatusUpdate(temperatureRawStatus: any) {
+  public getDefaultTempeatureSource() {
+    return TemperatureSource.BASKET_PROBE;
+  }
+
+  private parseStatusUpdate(
+    temperatureRawStatus: ArrayBuffer,
+    characteristic: string,
+  ) {
     this.logger.log(
       'temperatureRawStatus received is: ' + temperatureRawStatus,
     );
+
+    const temperatureDataview = new DataView(temperatureRawStatus);
+    const temperature = temperatureDataview.getFloat64(0, true);
+
     const formatNumber = new Intl.NumberFormat(undefined, {
       minimumIntegerDigits: 2,
     }).format;
 
-    const setPoint =
-      ((temperatureRawStatus.getUint16(5, true) / 127) * 5) / 9 - 32; // Convert from F to C
-    const data = formatNumber(setPoint);
+    const data = Number(formatNumber(temperature));
 
-    this.setTemperature(Number(data), temperatureRawStatus);
+    // set temperature on the correct source
+    switch (characteristic) {
+      case ArgosThermometer.TEMPERATURE_SETPOINT_CHAR_UUID:
+        this.state.setPoint = data;
+        this.setTemperature(
+          data,
+          temperatureDataview,
+          TemperatureSource.SET_POINT,
+        );
+        break;
+      case ArgosThermometer.TEMPERATURE_BOILER_CURRENT_CHAR_UUID:
+        if (this.state.setPoint != 0 && this.state.boilerTarget != 0) {
+          // calculate boiler error and approx water temp
+          const boilerError = data - this.state.boilerTarget;
+          const approxWaterTemp = Math.min(
+            this.state.setPoint + 0.5 * boilerError,
+            data,
+          );
+          this.setTemperature(
+            Number(formatNumber(approxWaterTemp)),
+            temperatureDataview,
+            TemperatureSource.BASKET_PROBE,
+          );
+        }
+        // send raw boiler temp
+        this.setTemperature(
+          data,
+          temperatureDataview,
+          TemperatureSource.WATER_PROBE,
+        );
+        break;
+      case ArgosThermometer.TEMPERATURE_BOILER_TARGET_CHAR_UUID:
+        this.state.boilerTarget = data;
+        break;
+    }
   }
 
   private deattachNotification() {
+    this.detachArgosNotification(
+      ArgosThermometer.TEMPERATURE_SETPOINT_CHAR_UUID,
+    );
+    this.detachArgosNotification(
+      ArgosThermometer.TEMPERATURE_BOILER_CURRENT_CHAR_UUID,
+    );
+    this.detachArgosNotification(
+      ArgosThermometer.TEMPERATURE_BOILER_TARGET_CHAR_UUID,
+    );
+  }
+
+  private detachArgosNotification(characteristic: string) {
     ble.stopNotification(
       this.device_id,
       ArgosThermometer.TEMPERATURE_SERVICE_UUID,
-      ArgosThermometer.TEMPERATURE_CHAR_UUID,
+      characteristic,
       (e: any) => {},
       (e: any) => {},
     );

--- a/src/classes/devices/temperatureBluetoothDevice.ts
+++ b/src/classes/devices/temperatureBluetoothDevice.ts
@@ -6,9 +6,16 @@ import { to128bitUUID } from './common/util';
 
 declare var ble: any;
 
+export enum TemperatureSource {
+  SET_POINT = 'SetPoint', // set point or goal for the shot
+  WATER_PROBE = 'WaterProbe', // last measured water temp before group (mix)
+  BASKET_PROBE = 'BasketProbe', // measured temp at group/basket, may or may not be in water path
+}
+
 export interface Temperature {
   actual: number;
   old: number;
+  source: TemperatureSource;
 }
 
 export interface TemperatureChangeEvent extends Temperature {
@@ -26,32 +33,49 @@ export abstract class TemperatureDevice {
   public batteryLevel: number;
   public temperatureChange: EventEmitter<TemperatureChangeEvent> =
     new EventEmitter();
-  protected temperature: Temperature;
+  protected temperatures = new Map<TemperatureSource, number>();
   protected temperatureParentLogger: Logger;
-
+  private defaultTemperatureSource;
   private lastTemperatureSetTime: number = 0;
 
-  protected constructor(data: PeripheralData) {
+  protected constructor(
+    data: PeripheralData,
+    defaultTemperatureSource: TemperatureSource = TemperatureSource.WATER_PROBE,
+  ) {
     this.device_id = data.id;
     try {
       this.device_name = data.name;
     } catch (ex) {}
-    this.temperature = {
-      actual: 0,
-      old: 0,
-    };
     this.temperatureParentLogger = new Logger();
+    this.defaultTemperatureSource = defaultTemperatureSource;
   }
 
   public abstract connect(): void;
   public abstract disconnect(): void;
 
-  public getTemperature() {
-    return this.temperature.actual;
+  public getDefaultTempeatureSource() {
+    return TemperatureSource.WATER_PROBE;
   }
 
-  public getOldTemperature() {
-    return this.temperature.old;
+  public getTemperature(
+    _source: TemperatureSource = this.defaultTemperatureSource,
+  ) {
+    return this.dataFor(_source).actual;
+  }
+
+  public getOldTemperature(
+    _source: TemperatureSource = this.defaultTemperatureSource,
+  ) {
+    return this.dataFor(_source).old;
+  }
+
+  private dataFor(_source: TemperatureSource) {
+    return (this.temperatures[_source] ??= {
+      actual: 0,
+      old: 0,
+      source: _source,
+      lastSetTime: 0,
+    });
   }
 
   /**
@@ -78,35 +102,42 @@ export abstract class TemperatureDevice {
       );
     });
   }
-
-  protected setTemperature(_newTemperature: number, _rawData: any) {
-    if (Date.now() - this.lastTemperatureSetTime < UPDATE_EVERY_MS) {
+  protected setTemperature(
+    _newTemperature: number,
+    _rawData: any,
+    _source: TemperatureSource = this.defaultTemperatureSource,
+  ) {
+    const temperatureData = this.dataFor(_source);
+    if (Date.now() - temperatureData.lastSetTime < UPDATE_EVERY_MS) {
       return;
     }
-    this.lastTemperatureSetTime = Date.now();
+    temperatureData.lastSetTime = Date.now();
 
     this.temperatureParentLogger.log(
       'Bluetooth Temperature Device - New temperature recieved ' +
         _newTemperature +
+        '- source ' +
+        _source +
         ' - raw data ' +
         JSON.stringify(_rawData),
     );
 
-    this.temperature.actual = _newTemperature;
+    temperatureData.actual = _newTemperature;
     const actualDate = new Date();
     try {
       this.temperatureParentLogger.log(
-        'Bluetooth Pressure Device - Are subscriptions existing? ' +
+        'Bluetooth Temperature Device - Are subscriptions existing? ' +
           this.temperatureChange?.observers?.length,
       );
     } catch (ex) {}
     this.temperatureChange.emit({
-      actual: this.temperature.actual,
-      old: this.temperature.old,
+      actual: temperatureData.actual,
+      old: temperatureData.old,
       date: actualDate,
+      source: temperatureData.source,
     });
 
-    this.temperature.old = _newTemperature;
+    temperatureData.old = _newTemperature;
   }
 }
 

--- a/src/classes/settings/settings.ts
+++ b/src/classes/settings/settings.ts
@@ -34,6 +34,7 @@ import { ListViewBrewParameter } from '../parameter/listViewBrewParameter';
 import { ManageBrewParameter } from '../parameter/manageBrewParameter';
 import { OrderBrewParameter } from '../parameter/orderBrewParameter';
 import { RepeatBrewParameter } from '../parameter/repeatBrewParameter';
+import { TemperatureSource } from '../devices/temperatureBluetoothDevice';
 
 export class Settings implements ISettings {
   public graph_colors: IGraphColors;
@@ -234,6 +235,9 @@ export class Settings implements ISettings {
   public temperature_threshold_active: boolean;
   public temperature_threshold_temp: number;
   public temperature_stay_connected: boolean;
+  public temperature_supported_sources: [TemperatureSource];
+  public temperature_graph_source: TemperatureSource;
+  public temperature_show_before_timer: boolean;
 
   public refractometer_id: string;
   public refractometer_type: RefractometerType;
@@ -588,6 +592,8 @@ export class Settings implements ISettings {
     this.temperature_threshold_active = false;
     this.temperature_threshold_temp = 92;
     this.temperature_stay_connected = false;
+    this.temperature_graph_source = TemperatureSource.WATER_PROBE;
+    this.temperature_show_before_timer = false;
 
     this.refractometer_id = '';
     this.refractometer_type = null;

--- a/src/components/brews/brew-brewing-graph/brew-brewing-graph.component.ts
+++ b/src/components/brews/brew-brewing-graph/brew-brewing-graph.component.ts
@@ -39,6 +39,11 @@ import {
   waterOutline,
 } from 'ionicons/icons';
 
+import {
+  TemperatureDevice,
+  TemperatureSource,
+} from '../../../classes/devices/temperatureBluetoothDevice';
+
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
 import moment from 'moment/moment';
 import regression from 'regression';
@@ -64,7 +69,6 @@ import {
   sleep,
 } from '../../../classes/devices';
 import { PressureDevice } from '../../../classes/devices/pressureBluetoothDevice';
-import { TemperatureDevice } from '../../../classes/devices/temperatureBluetoothDevice';
 import { Graph } from '../../../classes/graph/graph';
 import { Preparation } from '../../../classes/preparation/preparation';
 import { PreparationDeviceType } from '../../../classes/preparationDevice';
@@ -1045,7 +1049,7 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
         _firstStart === false
       ) {
         this.attachToTemperatureChange();
-      } else if (this.settings.temperature_threshold_active) {
+      } else if (this.settings.temperature_threshold_active === true || this.settings.temperature_show_before_timer === true) {
         this.attachToTemperatureChange();
       }
 
@@ -1183,7 +1187,7 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
 
   public setActualTemperatureInformation(_temperature) {
     this.ngZone.runOutsideAngular(() => {
-      if (this.brewComponent.maximizeFlowGraphIsShown === true) {
+       if (this.brewComponent.maximizeFlowGraphIsShown === true) {
         this.brewComponent.brewTemperatureGraphSubject.next({
           temperature: _temperature,
         });
@@ -1191,8 +1195,8 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
 
       try {
         const temperatureEl = this.temperatureEl.nativeElement;
-
-        temperatureEl.textContent = _temperature;
+        const temperatureFormatted = _temperature.toFixed(2);
+        temperatureEl.textContent = temperatureFormatted;
       } catch (ex) {}
     });
   }
@@ -1614,7 +1618,7 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
 
       if (temperatureDevice) {
         this.deattachToTemperatureChange();
-        if (this.settings.temperature_threshold_active === true) {
+        if (this.settings.temperature_threshold_active === true || this.settings.temperature_show_before_timer === true ) {
           // After attaching attach again
           this.attachToTemperatureChange();
         }
@@ -2372,7 +2376,7 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
       }
       if (
         temperatureDevice &&
-        (this.settings.temperature_threshold_active === false ||
+        ((this.settings.temperature_threshold_active === false && this.settings.temperature_show_before_timer === false) ||
           _event !== 'AUTO_START_TEMPERATURE')
       ) {
         this.attachToTemperatureChange();
@@ -2818,7 +2822,6 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
     if (temperatureDevice) {
       this.temperatureThresholdWasHit = false;
       this.deattachToTemperatureChange();
-
       this.temperatureDeviceSubscription =
         temperatureDevice.temperatureChange.subscribe((_val) => {
           if (this.brewComponent.timer.isTimerRunning()) {
@@ -2850,6 +2853,9 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
                   this.checkChanges();
                 });
               });
+            } else if(_val.source == this.settings.temperature_graph_source) {
+              // if timer isn't running yet, we can still update temperature information 
+              this.setActualTemperatureInformation(_val.actual);
             }
           }
         });
@@ -3671,12 +3677,22 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
       2,
     );
     const old: number = this.uiHelper.toFixedIfNecessary(_temperature.old, 2);
-
-    // If no smartscale is connected, the set temperature flow needs to be the master to set flowtime and flowtime seconds, else we just retrieve from the scale.
     const isSmartScaleConnected = this.smartScaleConnected();
-    if (this.flowTime === undefined) {
-      this.flowTime = this.brewComponent.getTime();
-      this.flowSecondTick = 0;
+
+    // only graph the source defined in settings
+    if (_temperature.source == this.settings.temperature_graph_source) {
+      if (this.flowTime === undefined) {
+        this.flowTime = this.brewComponent.getTime();
+        this.flowSecondTick = 0;
+      }
+
+      // If no smartscale is connected, the set temperature flow needs to be the master to set flowtime and flowtime seconds, else we just retrieve from the scale.
+      if (!isSmartScaleConnected) {
+        if (this.flowTime !== this.brewComponent.getTime()) {
+          this.flowTime = this.brewComponent.getTime();
+          this.flowSecondTick = 0;
+        }
+      }
     }
 
     const actualUnixTime: number = moment(new Date())
@@ -3693,29 +3709,26 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
       flowTimeSecond: this.flowTime + '.' + this.flowSecondTick,
     };
 
-    if (!isSmartScaleConnected) {
-      if (this.flowTime !== this.brewComponent.getTime()) {
-        this.flowTime = this.brewComponent.getTime();
-        this.flowSecondTick = 0;
-      }
-    }
-
-    this.traces.temperatureTrace.x.push(new Date(temperatureObj.unixTime));
-    this.traces.temperatureTrace.y.push(temperatureObj.actual);
-
     this.pushTemperatureProfile(
       temperatureObj.flowTimeSecond,
       temperatureObj.actual,
       temperatureObj.old,
+      _temperature.source,
     );
 
-    if (!isSmartScaleConnected) {
-      //Just update the chart if a smart scale is not connected - else it has huge performance issues on android
-      this.updateChart();
-      this.flowSecondTick++;
+    if (_temperature.source == this.settings.temperature_graph_source) {
+      this.traces.temperatureTrace.x.push(new Date(temperatureObj.unixTime));
+      this.traces.temperatureTrace.y.push(temperatureObj.actual);
+
+      if (!isSmartScaleConnected) {
+        //Just update the chart if a smart scale is not connected - else it has huge performance issues on android
+        this.updateChart();
+        this.flowSecondTick++;
+      }
+      this.setActualTemperatureInformation(temperatureObj.actual);
     }
 
-    this.setActualTemperatureInformation(temperatureObj.actual);
+   
   }
 
   private __setFlowProfile(_scaleChange: any) {
@@ -4499,6 +4512,7 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
     _brewTime: string,
     _actualTemperature: number,
     _oldTemperature: number,
+    _source: TemperatureSource,
   ) {
     const temperatureFlow: IBrewTemperatureFlow = {} as IBrewTemperatureFlow;
     temperatureFlow.timestamp = this.uiHelper.getActualTimeWithMilliseconds();
@@ -4506,7 +4520,17 @@ export class BrewBrewingGraphComponent implements OnInit, OnDestroy {
     temperatureFlow.actual_temperature = _actualTemperature;
     temperatureFlow.old_temperature = _oldTemperature;
 
-    this.flow_profile_raw.temperatureFlow.push(temperatureFlow);
+    switch (_source) {
+      case TemperatureSource.SET_POINT:
+        this.flow_profile_raw.targetTemperatureFlow.push(temperatureFlow);
+        break;
+      case TemperatureSource.BASKET_PROBE:
+        this.flow_profile_raw.basketTemperatureFlow.push(temperatureFlow);
+        break;
+      case TemperatureSource.WATER_PROBE:
+        this.flow_profile_raw.temperatureFlow.push(temperatureFlow);
+        break;
+    }
   }
 
   @HostListener('window:resize')

--- a/src/popover/bluetooth-device-chooser-popover/bluetooth-device-chooser-popover.component.ts
+++ b/src/popover/bluetooth-device-chooser-popover/bluetooth-device-chooser-popover.component.ts
@@ -395,6 +395,8 @@ export class BluetoothDeviceChooserPopoverComponent
       await this.uiAlert.hideLoadingSpinner();
       this.settings.temperature_id = temperatureDevice.id;
       this.settings.temperature_type = temperatureDevice.type;
+      this.settings.temperature_supported_sources =
+        temperatureDevice.supportedSources();
       this.uiAnalytics.trackEvent(
         BLUETOOTH_TRACKING.TITLE,
         BLUETOOTH_TRACKING.ACTIONS.TEMPERATURE_CONNECTED,

--- a/src/services/coffeeBluetoothDevices/coffee-bluetooth-devices.service.ts
+++ b/src/services/coffeeBluetoothDevices/coffee-bluetooth-devices.service.ts
@@ -1183,6 +1183,7 @@ export class CoffeeBluetoothDevicesService {
 
           try {
             const settings = this.uiStettingsStorage.getSettings();
+            settings.temperature_graph_source = this.getTemperatureDevice().getDefaultTempeatureSource();
             if (settings.bluetooth_devices_show_connection_messages === true) {
               this.uiToast.showInfoToast(
                 this.translate.instant('TEMPERATURE.CONNECTED_SUCCESSFULLY') +


### PR DESCRIPTION
**Multiple temperature sources**
- add basic support for three temperature sources, which line up which Visualizer
- each multi-source temperature device can select which source is shown on the graph (future; maybe user option?)
- all sources are sent to visualizer

**Show temperature before timer**
- adds setting for showing temperature before timer starts, handy for temp surfing 
- will require translations (sorry)

**Argos Support**
- listen to all Argos bluetooth events to support multi temperature
- calculated the approximate output temperature based on set point and boiler error (difference) <--- extremely rough but works well when within ~1 deg C or so 
- only graph the estimated output temp, boiler and set point, sent to visualizer

**Misc/Notes**
- cleans up temperature display, lock to two decimals
- Visualizer will only show Argos boiler data until an update can be made to support all three temps (output == basket, boiler == mix, set point == goal)

Visualizer PR: https://github.com/miharekar/visualizer/pull/220