### PR TITLE
fixed visualizer custom url in brew information view

### DIFF
--- a/src/components/brew-information/brew-information.component.ts
+++ b/src/components/brew-information/brew-information.component.ts
@@ -248,7 +248,9 @@ export class BrewInformationComponent implements OnInit {
 
   public async showVisualizerShot() {
     this.uiHelper.openExternalWebpage(
-      'https://visualizer.coffee/shots/' +
+      // Visualizer URL should be in the right format due to checkVisualizerURL method in settings.ts
+      this.settings.visualizer_url +
+        'shots/' +
         this.brew.customInformation.visualizer_id,
     );
   }


### PR DESCRIPTION
Fixed the URL for the visualizer in the Brew Information view. Previously, it was pointing to the wrong URL when using a custom server.