### PR TITLE
Fix virtual scroll elements not rendering their content in some cases

### DIFF
--- a/src/app/beans/bean-modal-select/bean-modal-select.component.ts
+++ b/src/app/beans/bean-modal-select/bean-modal-select.component.ts
@@ -255,7 +255,7 @@ export class BeanModalSelectComponent implements OnInit {
   }
 
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.beanContent.nativeElement;
       let scrollComponent: AgVirtualScrollComponent;
       if (this.openScroll !== undefined) {
@@ -277,6 +277,16 @@ export class BeanModalSelectComponent implements OnInit {
         scrollComponent.el.offsetTop +
         'px';
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
     }, 250);
   }
 

--- a/src/app/beans/bean-popover-frozen-list/bean-popover-frozen-list.component.ts
+++ b/src/app/beans/bean-popover-frozen-list/bean-popover-frozen-list.component.ts
@@ -57,13 +57,22 @@ export class BeanPopoverFrozenListComponent {
   }
 
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.beanContent.nativeElement;
-      let scrollComponent: AgVirtualScrollComponent;
-      scrollComponent = this.openScroll;
+      const scrollComponent = this.openScroll;
       scrollComponent.el.style.height =
         el.offsetHeight - scrollComponent.el.offsetTop + 'px';
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
     }, 150);
   }
 

--- a/src/app/beans/bean-popover-list/bean-popover-list.component.ts
+++ b/src/app/beans/bean-popover-list/bean-popover-list.component.ts
@@ -55,13 +55,22 @@ export class BeanPopoverListComponent {
   }
 
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.beanContent.nativeElement;
-      let scrollComponent: AgVirtualScrollComponent;
-      scrollComponent = this.openScroll;
+      const scrollComponent = this.openScroll;
       scrollComponent.el.style.height =
         el.offsetHeight - scrollComponent.el.offsetTop + 'px';
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
     }, 150);
   }
 

--- a/src/app/beans/beans.page.ts
+++ b/src/app/beans/beans.page.ts
@@ -407,7 +407,7 @@ export class BeansPage implements OnDestroy {
   }
 
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.beanContent.nativeElement;
       let scrollComponent: AgVirtualScrollComponent;
       if (this.openScroll !== undefined) {
@@ -421,6 +421,17 @@ export class BeansPage implements OnDestroy {
       scrollComponent.el.style.height =
         el.offsetHeight - scrollComponent.el.offsetTop + 'px';
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
+
       setTimeout(() => {
         /** If we wouldn't do it, and the tiles are collapsed, the next once just exist when the user starts scrolling**/
         const elScroll = scrollComponent.el;

--- a/src/app/brew/associated-brews/associated-brews.component.ts
+++ b/src/app/brew/associated-brews/associated-brews.component.ts
@@ -83,7 +83,7 @@ export class AssociatedBrewsComponent {
   }
 
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.associatedBrewsComponent.nativeElement;
       const scrollComponent: AgVirtualScrollComponent =
         this.openScrollAssociatedBrews;
@@ -93,6 +93,16 @@ export class AssociatedBrewsComponent {
           el.offsetHeight - scrollComponent.el.offsetTop - 20 + 'px';
 
         this.segmentScrollHeight = scrollComponent.el.style.height;
+
+        // HACK: Manually trigger component refresh to work around initialization
+        //       bug. For some reason the scroll component sees its own height as
+        //       0 during initialization, which causes it to render 0 items. As
+        //       no changes to the component occur after initialization, no
+        //       re-render ever occurs. This forces one. The root cause for
+        //       this issue is currently unknown.
+        if (scrollComponent.items.length === 0) {
+          scrollComponent.refreshData();
+        }
         setTimeout(() => {
           /** If we wouldn't do it, and the tiles are collapsed, the next once just exist when the user starts scrolling**/
           const elScroll = scrollComponent.el;

--- a/src/app/brew/brew-choose-graph-reference/brew-choose-graph-reference.component.ts
+++ b/src/app/brew/brew-choose-graph-reference/brew-choose-graph-reference.component.ts
@@ -179,7 +179,7 @@ export class BrewChooseGraphReferenceComponent implements OnInit {
   }
 
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.brewContent.nativeElement;
 
       const footerEl = this.footerContent.nativeElement;
@@ -192,14 +192,26 @@ export class BrewChooseGraphReferenceComponent implements OnInit {
       } else if (this.graphOpenScroll !== undefined) {
         scrollComponent = this.graphOpenScroll;
       }
-      if (scrollComponent) {
-        scrollComponent.el.style.height =
-          el.offsetHeight -
-          footerEl.offsetHeight -
-          15 -
-          scrollComponent.el.offsetTop +
-          'px';
-        this.segmentScrollHeight = scrollComponent.el.style.height;
+      if (!scrollComponent) {
+        return;
+      }
+
+      scrollComponent.el.style.height =
+        el.offsetHeight -
+        footerEl.offsetHeight -
+        15 -
+        scrollComponent.el.offsetTop +
+        'px';
+      this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
       }
     }, 150);
   }

--- a/src/app/brew/brew-modal-import-shot-gaggiuino/brew-modal-import-shot-gaggiuino.component.ts
+++ b/src/app/brew/brew-modal-import-shot-gaggiuino/brew-modal-import-shot-gaggiuino.component.ts
@@ -132,14 +132,26 @@ export class BrewModalImportShotGaggiuinoComponent implements OnInit {
   }
 
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.historyShotContent.nativeElement;
       const scrollComponent: AgVirtualScrollComponent =
         this.gaggiuinoShotDataScroll;
 
-      if (scrollComponent) {
-        scrollComponent.el.style.height = el.offsetHeight - 20 + 'px';
-        // this.segmentScrollHeight = scrollComponent.el.style.height;
+      if (!scrollComponent) {
+        return;
+      }
+
+      scrollComponent.el.style.height = el.offsetHeight - 20 + 'px';
+      // this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
       }
     }, 150);
   }

--- a/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
+++ b/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
@@ -101,13 +101,25 @@ export class BrewModalImportShotMeticulousComponent implements OnInit {
   }
 
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.historyShotContent.nativeElement;
       const scrollComponent: AgVirtualScrollComponent = this.shotDataScroll;
 
-      if (scrollComponent) {
-        scrollComponent.el.style.height = el.offsetHeight - 20 + 'px';
-        this.segmentScrollHeight = scrollComponent.el.style.height;
+      if (!scrollComponent) {
+        return;
+      }
+
+      scrollComponent.el.style.height = el.offsetHeight - 20 + 'px';
+      this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
       }
     }, 150);
   }

--- a/src/app/brew/brew.page.ts
+++ b/src/app/brew/brew.page.ts
@@ -169,6 +169,16 @@ export class BrewPage implements OnInit {
         el.offsetHeight - scrollComponent.el.offsetTop + 'px';
 
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
       setTimeout(() => {
         /** If we wouldn't do it, and the tiles are collapsed, the next once just exist when the user starts scrolling**/
         const elScroll = scrollComponent.el;

--- a/src/app/graph-section/graph/graph.page.ts
+++ b/src/app/graph-section/graph/graph.page.ts
@@ -110,7 +110,7 @@ export class GraphPage implements OnInit {
     this.retriggerScroll();
   }
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.graphContent.nativeElement;
       let scrollComponent: AgVirtualScrollComponent;
       if (this.openScroll !== undefined) {
@@ -123,6 +123,16 @@ export class GraphPage implements OnInit {
         el.offsetHeight - scrollComponent.el.offsetTop + 'px';
 
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
     }, 250);
   }
 

--- a/src/app/mill/mill.page.ts
+++ b/src/app/mill/mill.page.ts
@@ -93,7 +93,7 @@ export class MillPage implements OnInit {
     this.retriggerScroll();
   }
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.millContent.nativeElement;
       let scrollComponent: AgVirtualScrollComponent;
       if (this.openScroll !== undefined) {
@@ -105,6 +105,16 @@ export class MillPage implements OnInit {
       scrollComponent.el.style.height =
         el.offsetHeight - scrollComponent.el.offsetTop + 'px';
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
     }, 150);
   }
 

--- a/src/app/preparation/preparation.page.ts
+++ b/src/app/preparation/preparation.page.ts
@@ -105,7 +105,7 @@ export class PreparationPage implements OnInit {
     this.retriggerScroll();
   }
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.preparationContent.nativeElement;
       let scrollComponent: AgVirtualScrollComponent;
       if (this.openScroll !== undefined) {
@@ -118,6 +118,16 @@ export class PreparationPage implements OnInit {
         el.offsetHeight - scrollComponent.el.offsetTop + 'px';
 
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
     }, 150);
   }
 

--- a/src/app/roasting-section/green-beans/green-beans.page.ts
+++ b/src/app/roasting-section/green-beans/green-beans.page.ts
@@ -125,7 +125,7 @@ export class GreenBeansPage implements OnInit {
     this.retriggerScroll();
   }
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.greenBeanContent.nativeElement;
       let scrollComponent: AgVirtualScrollComponent;
       if (this.openScroll !== undefined) {
@@ -138,6 +138,16 @@ export class GreenBeansPage implements OnInit {
         el.offsetHeight - scrollComponent.el.offsetTop + 'px';
 
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
     }, 250);
   }
 

--- a/src/app/water-section/water/water.page.ts
+++ b/src/app/water-section/water/water.page.ts
@@ -110,7 +110,7 @@ export class WaterPage implements OnInit {
     this.retriggerScroll();
   }
   private retriggerScroll() {
-    setTimeout(async () => {
+    setTimeout(() => {
       const el = this.waterContent.nativeElement;
       let scrollComponent: AgVirtualScrollComponent;
       if (this.openScroll !== undefined) {
@@ -122,6 +122,16 @@ export class WaterPage implements OnInit {
       scrollComponent.el.style.height =
         el.offsetHeight - scrollComponent.el.offsetTop + 'px';
       this.segmentScrollHeight = scrollComponent.el.style.height;
+
+      // HACK: Manually trigger component refresh to work around initialization
+      //       bug. For some reason the scroll component sees its own height as
+      //       0 during initialization, which causes it to render 0 items. As
+      //       no changes to the component occur after initialization, no
+      //       re-render ever occurs. This forces one. The root cause for
+      //       this issue is currently unknown.
+      if (scrollComponent.items.length === 0) {
+        scrollComponent.refreshData();
+      }
     }, 250);
   }
 


### PR DESCRIPTION
For some unknown reason the virtual scroll component sees its own height as 0 during initialization in some cases. When it does, it doesn't render any elements as it thinks it's empty.

As a workaround, this commit will now force the virtual scroll component to re-render in the existing retriggerScroll() function if it doesn't show any content yet.