### PR TITLE
ci: Update setup-node to v6 and node to v24 (current LTS)

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -15,9 +15,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22.x
+          node-version: 24.x
           cache: 'npm'
       - run: npm ci
       - run: npm run build --if-present


### PR DESCRIPTION
Hopefully this fixes the CI errors about package-lock.json not matching package.json. Locally I don't get any errors with npm 11.8.0.

npm also doesn't seem to be able to get their story straight. Lockfiles created from 11.x version SHOULD apparently be compatible with 10.x versions, but are not compatible in practice. See the following issues (and countless other ones linked in those):

* https://github.com/npm/cli/issues/6787
* https://github.com/npm/cli/issues/8726
* https://github.com/npm/cli/issues/8669