### PR TITLE
ci: Update npm to at least version 11.8.0 to fix lockfile issues

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -19,6 +19,8 @@ jobs:
         with:
           node-version: 24.x
           cache: 'npm'
+      # Update npm version to at least 11.8.0, which should fix npm not liking our lockfiles
+      - run: npm install -g 'npm@^11.8.0' && npm -v
       - run: npm ci
       - run: npm run build --if-present
       - run: npm test


### PR DESCRIPTION
Now fixed for real :tm:, see https://github.com/RagingCactus/Beanconqueror/actions/runs/21919617991

---

The bundled npm version in the GitHub action does not like our lockfile and complains it is not in sync with package.json. It is. My local 11.8.0 confirms that.

So let's just get it over with by updating npm. Hopefully they don't break the lockfile/package resolution _again_ later.