### PR TITLE
Fix broken ESLint after pnpm migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "@angular/language-service": "^21.0.6",
     "@capacitor/assets": "^3.0.5",
     "@capacitor/cli": "^8.0.0",
+    "@eslint/js": "^9.39.4",
     "@ianvs/prettier-plugin-sort-imports": "^4.7.0",
     "@ionic/angular-toolkit": "^12.3.0",
     "@types/jasmine": "^5.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -231,6 +231,9 @@ importers:
       '@capacitor/cli':
         specifier: ^8.0.0
         version: 8.2.0
+      '@eslint/js':
+        specifier: ^9.39.4
+        version: 9.39.4
       '@ianvs/prettier-plugin-sort-imports':
         specifier: ^4.7.0
         version: 4.7.1(prettier@3.8.1)


### PR DESCRIPTION
During the pnpm migration I forgot to add an explicit dependency on `@eslint/js`. The dependency has always been there, it was just 'hidden' as a transitive dependency because of npm hoisting.