### PR TITLE
Fix pnpm minimum release age configuration

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@
 # defend against increasingly common supply chain attacks on npm packages.
 # See https://pnpm.io/settings#minimumreleaseage and
 # https://pnpm.io/supply-chain-security
-minimum-release-age: 10080
+minimumReleaseAge: 10080
 
 # Print an error for unreviewed build scripts
 strictDepBuilds: true


### PR DESCRIPTION
I messed up one config key in the pnpm configuration and didn't notice because locally I have also set the same setting in my user configuration. Sorry about that.

Now it actually works, I verified it. This is the correct config key name now.

There are already some packages in the lockfile, so now we have to wait 7 days before merging to avoid error messages. So this should be ready to merge on 2026-04-28, unless we touch the lockfile again in the meantime.