### PR TITLE
feat: refactor Meticulous shot import to use infinite scroll, link to profile selection

### DIFF
--- a/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
+++ b/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
@@ -4,6 +4,7 @@ import {
   HostListener,
   inject,
   Input,
+  OnDestroy,
   OnInit,
   ViewChild,
 } from '@angular/core';
@@ -59,7 +60,9 @@ import { UIHelper } from '../../../services/uiHelper';
     IonCol,
   ],
 })
-export class BrewModalImportShotMeticulousComponent implements OnInit {
+export class BrewModalImportShotMeticulousComponent
+  implements OnInit, OnDestroy
+{
   private readonly modalController = inject(ModalController);
   readonly uiHelper = inject(UIHelper);
   private readonly uiAlert = inject(UIAlert);
@@ -67,8 +70,14 @@ export class BrewModalImportShotMeticulousComponent implements OnInit {
   public static COMPONENT_ID: string = 'brew-modal-import-shot-meticulous';
 
   @Input() public meticulousDevice: MeticulousDevice;
+  @Input() public profileFilter: string | undefined;
   public radioSelection: string;
-  public history: Array<HistoryListingEntry> = [];
+  public history: HistoryListingEntry[] = [];
+  public hasMore = true;
+  public isLoadingMore = false;
+
+  private lastEntryTime: number | undefined;
+  private boundScrollHandler: ((event: Event) => void) | undefined;
 
   @ViewChild('ionItemEl', { read: ElementRef, static: false })
   public ionItemEl: ElementRef;
@@ -90,10 +99,25 @@ export class BrewModalImportShotMeticulousComponent implements OnInit {
     this.readHistory();
   }
 
+  public ngOnDestroy() {
+    if (this.shotDataScroll && this.boundScrollHandler) {
+      this.shotDataScroll.el.removeEventListener(
+        'scroll',
+        this.boundScrollHandler,
+      );
+    }
+  }
+
   private async readHistory() {
     await this.uiAlert.showLoadingSpinner();
     try {
-      this.history = await this.meticulousDevice?.getHistory();
+      const results = await this.meticulousDevice?.getHistory(
+        undefined,
+        this.profileFilter,
+      );
+      this.history = results ?? [];
+      this.lastEntryTime = this.history[this.history.length - 1]?.time;
+      this.hasMore = this.history.length >= MeticulousDevice.PAGE_SIZE;
     } catch (ex) {
       await this.uiAlert.showMessage(
         'PREPARATION_DEVICE.TYPE_METICULOUS.DATA_COULD_NOT_BE_LOADED',
@@ -105,6 +129,36 @@ export class BrewModalImportShotMeticulousComponent implements OnInit {
     await this.uiAlert.hideLoadingSpinner();
     this.retriggerScroll();
   }
+
+  public async loadMoreHistory() {
+    if (
+      !this.hasMore ||
+      this.isLoadingMore ||
+      this.lastEntryTime === undefined
+    ) {
+      return;
+    }
+    this.isLoadingMore = true;
+    try {
+      const results = await this.meticulousDevice?.getHistory(
+        this.lastEntryTime,
+        this.profileFilter,
+      );
+      const allResults = results ?? [];
+      const newEntries = allResults.filter(
+        (entry) => !this.history.some((existing) => existing.id === entry.id),
+      );
+      this.history = [...this.history, ...newEntries];
+      this.lastEntryTime = this.history[this.history.length - 1]?.time;
+      this.hasMore =
+        allResults.length >= MeticulousDevice.PAGE_SIZE &&
+        newEntries.length > 0;
+    } catch (ex) {
+      // silently fail — scroll triggers a retry naturally
+    }
+    this.isLoadingMore = false;
+  }
+
   @HostListener('window:resize')
   @HostListener('window:orientationchange')
   public onOrientationChange() {
@@ -132,7 +186,22 @@ export class BrewModalImportShotMeticulousComponent implements OnInit {
       if (scrollComponent.items.length === 0) {
         scrollComponent.refreshData();
       }
+
+      this.attachScrollListener();
     }, 150);
+  }
+
+  private attachScrollListener() {
+    if (this.boundScrollHandler || !this.shotDataScroll) {
+      return;
+    }
+    this.boundScrollHandler = (event: Event) => {
+      const target = event.target as HTMLElement;
+      if (target.scrollHeight - target.scrollTop - target.clientHeight < 100) {
+        this.loadMoreHistory();
+      }
+    };
+    this.shotDataScroll.el.addEventListener('scroll', this.boundScrollHandler);
   }
 
   public getElementOffsetWidth() {

--- a/src/classes/preparationDevice/meticulous/meticulousDevice.ts
+++ b/src/classes/preparationDevice/meticulous/meticulousDevice.ts
@@ -1,11 +1,9 @@
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 
 import Api, { ActionType, ProfileIdent } from '@meticulous-home/espresso-api';
 import { HistoryListingEntry } from '@meticulous-home/espresso-api/dist/types';
 import { Profile } from '@meticulous-home/espresso-profile';
 import moment from 'moment';
-import { of } from 'rxjs';
-import { catchError, timeout } from 'rxjs/operators';
 
 import { IMeticulousParams } from '../../../interfaces/preparationDevices/meticulous/iMeticulousParams';
 import {
@@ -23,14 +21,14 @@ declare var cordova;
 declare var io;
 
 export class MeticulousDevice extends PreparationDevice {
+  public static readonly PAGE_SIZE = 3;
+
   private socket: any = undefined;
   private meticulousShotData: MeticulousShotData = undefined;
   private _isConnected: boolean = false;
   private metApi: Api = undefined;
 
   private _profiles: Array<Profile> = [];
-
-  private serverURL: string = '';
 
   public static returnBrewFlowForShotData(_shotData) {
     const newMoment = moment(new Date()).startOf('day');
@@ -89,50 +87,26 @@ export class MeticulousDevice extends PreparationDevice {
       undefined,
       _preparation.connectedPreparationDevice.url,
     );
-    this.serverURL = _preparation.connectedPreparationDevice.url;
-
     if (typeof cordova !== 'undefined') {
     }
   }
-  public getHistory() {
-    const promise = new Promise<any>((resolve, reject) => {
-      const httpOptions = {
-        headers: new HttpHeaders({
-          'Content-Type': 'application/json',
-        }),
-      };
-      this.httpClient
-        .post(
-          this.serverURL + '/api/v1/history',
-          {
-            sort: 'desc',
-            max_results: 20,
-          },
-          httpOptions,
-        )
-        .pipe(
-          timeout(10000),
-          catchError((e) => {
-            reject();
-            return of(null);
-          }),
-        )
-        .toPromise()
-        .then(
-          (data: any) => {
-            if (data && data.history) {
-              resolve(data.history);
-            }
-          },
-          (error) => {
-            reject();
-          },
-        )
-        .catch((error) => {
-          reject();
-        });
-    });
-    return promise;
+  public async getHistory(
+    endDate?: number,
+    profileFilter?: string,
+  ): Promise<HistoryListingEntry[]> {
+    const params: any = {
+      query: profileFilter ?? '',
+      ids: [],
+      order_by: ['date'],
+      sort: 'desc',
+      max_results: MeticulousDevice.PAGE_SIZE,
+      dump_data: true,
+    };
+    if (endDate !== undefined) {
+      params.end_date = endDate;
+    }
+    const response = await this.metApi.searchHistory(params);
+    return (response?.data?.history as unknown as HistoryListingEntry[]) ?? [];
   }
 
   public getActualShotData() {

--- a/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.ts
+++ b/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.ts
@@ -666,11 +666,21 @@ export class BrewBrewingPreparationDeviceComponent implements OnInit {
   }
 
   public async importShotFromMeticulous() {
+    const meticulousDevice = this.preparationDevice as MeticulousDevice;
+    const chosenProfileId = (
+      this.data.preparationDeviceBrew.params as MeticulousParams
+    )?.chosenProfileId;
+    const profileFilter = chosenProfileId
+      ? meticulousDevice.getProfiles().find((p) => p.id === chosenProfileId)
+          ?.name
+      : undefined;
+
     const modal = await this.modalController.create({
       component: BrewModalImportShotMeticulousComponent,
       id: BrewModalImportShotMeticulousComponent.COMPONENT_ID,
       componentProps: {
-        meticulousDevice: this.preparationDevice as MeticulousDevice,
+        meticulousDevice,
+        profileFilter,
       },
     });
 
@@ -883,6 +893,11 @@ export class BrewBrewingPreparationDeviceComponent implements OnInit {
     if (_historyData.profile?.temperature) {
       this.brewComponent.data.brew_temperature =
         _historyData.profile.temperature;
+    }
+    if (_historyData.profile?.id) {
+      (
+        this.data.preparationDeviceBrew.params as MeticulousParams
+      ).chosenProfileId = _historyData.profile.id;
     }
 
     /**Set the custom creation date, the user needs to activate the parameter for custom creation date**/


### PR DESCRIPTION
## Problem

The Meticulous "Import Shot" method has 2 major limitations:

1. It loads the most recent 20 shots, which is a lot of data to load at once and adds latency to the API response time. Most people only want the most recent 1-2 shots, since they are usually only importing the shot that they just extracted. Making them wait for all 20 shots to load is a waste of their time.
2. It **only** loads the most recent 20 shots. If you want to import a shot that is older than that... you can't.

Fixing the length at 20 condemns you to a single slow API call that is likely either much more than you want, or less then you need.

Additionally, when you import a shot, it has a particular profile, like "Simple" or "Soup." But it doesn't set the chosen profile when you import it, meaning that it will not be set unless you remember to do that by hand.

Also, if you choose a profile first, the shot import will not respect it—it just loads the most recent 20 shots that you pulled, regardless of which profile it was.

## Solution

- Implement pagination and infinite scrolling. The Meticulous history API supports arbitrary max_results, and allows passing the `time` of the last shot as the `end_date` to allow you to page through API responses. If we keep track of the last shot's `time`, we can pass that as `end_date` to a new API call when the user scrolls to the end of the history list, loading up more results, until they hit the end.
- Update the brew modal import to set `this.profileFilter` from `chosenProfileId`, and pass it to the history loading call, so that it will respect the user's chosen profile if they set one.
- Link up `chosenProfileId` into `generateShotFlowProfileFromMeticulousData`, so that the profile is set when importing.

This results in a much improved user experience importing Meticulous shots. They load up very quickly—learly instantly even on a kind of bad network—and then you can scroll and scroll to see more and more if you need to. It also sets your profile automatically, so you don't have to remember to do that.

### AI Disclosure

I am an experienced developer, but I don't work much with js/typescript. I implemented this using Claude Code. All the changes look reasonable to me as a software developer, and I tested it locally with my machine to make sure it works right.