### PR TITLE
Pin checksum of xlsx in pnpm-lock.yaml

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5556,7 +5556,7 @@ packages:
     engines: {node: '>=10.0.0'}
 
   xlsx@https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz:
-    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz}
+    resolution: {tarball: https://cdn.sheetjs.com/xlsx-0.20.3/xlsx-0.20.3.tgz, integrity: sha512-oLDq3jw7AcLqKWH2AhCpVTZl8mf6X2YReP+Neh0SJUzV/BdZYjth94tG5toiMB1PPrYtxOCfaoUCkvtuH+3AJA==}
     version: 0.20.3
     engines: {node: '>=0.8'}
     hasBin: true


### PR DESCRIPTION
Newer pnpm versions require the checksum for tarball dependencies.