### PR TITLE
fix: Fix Meticulous shot import scroll reset and correct profile parameter handling

### DIFF
--- a/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.html
+++ b/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.html
@@ -14,7 +14,7 @@
               <h2>{{entry.profile.name}}</h2>
               <div class='font-size-16'>{{this.uiHelper.formatTimeNumber(entry.time * 1000)}}</div>
               </ion-grid>
-              <graph-display-card [chartWidth]='getElementOffsetWidth()' [meticulousHistoryData]='entry'></graph-display-card>
+              <graph-display-card [chartWidth]='getElementOffsetWidth()' [meticulousHistoryData]='entry' [meticulousDevice]='meticulousDevice'></graph-display-card>
             </ion-radio>
           </ion-item>
         }

--- a/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.html
+++ b/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.html
@@ -14,7 +14,7 @@
               <h2>{{entry.profile.name}}</h2>
               <div class='font-size-16'>{{this.uiHelper.formatTimeNumber(entry.time * 1000)}}</div>
               </ion-grid>
-              <graph-display-card [chartWidth]='getElementOffsetWidth()' [meticulousHistoryData]='entry' [meticulousDevice]='meticulousDevice'></graph-display-card>
+              <graph-display-card [chartWidth]='chartWidth' [meticulousHistoryData]='entry' [meticulousDevice]='meticulousDevice'></graph-display-card>
             </ion-radio>
           </ion-item>
         }

--- a/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
+++ b/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
@@ -75,7 +75,6 @@ export class BrewModalImportShotMeticulousComponent
   public hasMore = true;
   public isLoadingMore = false;
   private isDestroyed = false;
-  private isBatchLoadingDetails = false;
   private lastEntryTime: number | undefined;
   private boundScrollHandler: ((event: Event) => void) | undefined;
 
@@ -119,7 +118,6 @@ export class BrewModalImportShotMeticulousComponent
       this.history = results ?? [];
       this.lastEntryTime = this.history[this.history.length - 1]?.time;
       this.hasMore = this.history.length >= MeticulousDevice.PAGE_SIZE;
-      void this.loadHistoryDetailsInBackground();
     } catch (ex) {
       await this.uiAlert.showMessage(
         'PREPARATION_DEVICE.TYPE_METICULOUS.DATA_COULD_NOT_BE_LOADED',
@@ -155,43 +153,10 @@ export class BrewModalImportShotMeticulousComponent
       this.hasMore =
         allResults.length >= MeticulousDevice.PAGE_SIZE &&
         newEntries.length > 0;
-      void this.loadHistoryDetailsInBackground();
     } catch (ex) {
       // silently fail — scroll triggers a retry naturally
     }
     this.isLoadingMore = false;
-  }
-
-  private async loadHistoryDetailsInBackground() {
-    if (this.isBatchLoadingDetails) {
-      return;
-    }
-    this.isBatchLoadingDetails = true;
-    try {
-      const currentHistory = [...this.history];
-      for (const entry of currentHistory) {
-        if (this.isDestroyed) {
-          break;
-        }
-        if (entry && !entry.data) {
-          try {
-            const details = await this.meticulousDevice?.getHistoryEntryDetails(
-              entry.id,
-            );
-            if (details?.data) {
-              const updatedEntry = { ...entry, data: details.data };
-              this.history = this.history.map((item) =>
-                item.id === entry.id ? updatedEntry : item,
-              );
-            }
-          } catch {
-            // ignore error
-          }
-        }
-      }
-    } finally {
-      this.isBatchLoadingDetails = false;
-    }
   }
 
   @HostListener('window:resize')
@@ -278,7 +243,7 @@ export class BrewModalImportShotMeticulousComponent
       BrewModalImportShotMeticulousComponent.COMPONENT_ID,
     );
   }
-  public choose(): void {
+  public async choose(): Promise<void> {
     let returningData;
 
     for (const entry of this.history) {
@@ -287,6 +252,22 @@ export class BrewModalImportShotMeticulousComponent
         break;
       }
     }
+
+    // The selected entry's shot data is loaded lazily once its card renders.
+    // Guarantee it is present before handing the entry back to the importer.
+    if (returningData && !returningData.data) {
+      try {
+        const details = await this.meticulousDevice?.getHistoryEntryDetails(
+          returningData.id,
+        );
+        if (details?.data) {
+          returningData.data = details.data;
+        }
+      } catch {
+        // ignore - importer guards against missing data
+      }
+    }
+
     void this.modalController.dismiss(
       {
         choosenHistory: returningData,

--- a/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
+++ b/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
@@ -72,6 +72,7 @@ export class BrewModalImportShotMeticulousComponent
   @Input() public profileFilter: string | undefined;
   public radioSelection: string;
   public history: any[] = [];
+  public chartWidth = 0;
   public hasMore = true;
   public isLoadingMore = false;
   private isDestroyed = false;
@@ -187,6 +188,7 @@ export class BrewModalImportShotMeticulousComponent
         scrollComponent.refreshData();
       }
 
+      this.updateChartWidth();
       this.attachScrollListener();
       this.checkAndLoadMoreIfNeeded();
     }, 150);
@@ -227,11 +229,14 @@ export class BrewModalImportShotMeticulousComponent
     }
   }
 
-  public getElementOffsetWidth() {
-    if (this.ionItemEl?.nativeElement?.offsetWidth) {
-      return this.ionItemEl?.nativeElement?.offsetWidth - 50;
-    }
-    return 0;
+  // Cache the chart width into a property rather than binding a layout-reading
+  // method in the template. Reading offsetWidth during change detection returns
+  // different values before and after layout, which triggers
+  // ExpressionChangedAfterItHasBeenCheckedError. This runs inside the
+  // retriggerScroll/resize timeouts, i.e. its own change detection cycle.
+  private updateChartWidth() {
+    const offsetWidth = this.ionItemEl?.nativeElement?.offsetWidth;
+    this.chartWidth = offsetWidth ? offsetWidth - 50 : 0;
   }
 
   public dismiss(): void {

--- a/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.ts
+++ b/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.ts
@@ -227,6 +227,19 @@ export class BrewBrewingPreparationDeviceComponent
     return this.uiPreparationStorage.getByUUID(this.data.method_of_preparation);
   }
 
+  /**
+   * Whether the "Profile" brew parameter is active for the current brew,
+   * mirroring the brewFieldVisiblePipe logic: a preparation using custom
+   * parameters overrides the global setting.
+   */
+  private isProfileParameterActive(): boolean {
+    const preparation = this.getPreparation();
+    if (preparation?.use_custom_parameters) {
+      return preparation.manage_parameters.pressure_profile;
+    }
+    return this.settings.manage_parameters.pressure_profile;
+  }
+
   public async instance() {
     await this.instancePreparationDevice(this.data);
   }
@@ -1118,17 +1131,12 @@ export class BrewBrewingPreparationDeviceComponent
     const lastEntry = newBrewFlow.weight[newBrewFlow.weight.length - 1];
     this.brewComponent.data.brew_beverage_quantity = lastEntry.actual_weight;
 
-    if (_historyData.profile?.name) {
+    if (_historyData.profile?.name && this.isProfileParameterActive()) {
       this.brewComponent.data.pressure_profile = _historyData.profile.name;
     }
     if (_historyData.profile?.temperature) {
       this.brewComponent.data.brew_temperature =
         _historyData.profile.temperature;
-    }
-    if (_historyData.profile?.id) {
-      (
-        this.data.preparationDeviceBrew.params as MeticulousParams
-      ).chosenProfileId = _historyData.profile.id;
     }
 
     /**Set the custom creation date, the user needs to activate the parameter for custom creation date**/

--- a/src/components/graph-display-card/graph-display-card.component.ts
+++ b/src/components/graph-display-card/graph-display-card.component.ts
@@ -40,6 +40,7 @@ export class GraphDisplayCardComponent implements OnInit, OnChanges, OnDestroy {
   @Input() public flowProfilePath: any;
 
   @Input() public meticulousHistoryData: HistoryListingEntry;
+  @Input() public meticulousDevice: MeticulousDevice;
   @Input() public gaggiuinoHistoryData: BrewFlow;
 
   @Input() public chartWidth: number;
@@ -64,6 +65,7 @@ export class GraphDisplayCardComponent implements OnInit, OnChanges, OnDestroy {
     } else if (this.flowProfileData) {
       this.flow_profile_raw = this.uiHelper.cloneData(this.flowProfileData);
     } else if (this.meticulousHistoryData) {
+      await this.ensureMeticulousShotData();
       this.flow_profile_raw = MeticulousDevice.returnBrewFlowForShotData(
         this.meticulousHistoryData.data,
       );
@@ -91,6 +93,33 @@ export class GraphDisplayCardComponent implements OnInit, OnChanges, OnDestroy {
         );
         this.initializeFlowChart();
       }
+    }
+  }
+
+  /**
+   * History listing entries are loaded without their shot data for
+   * performance. When a card is actually rendered we lazily fetch the detail
+   * for its own entry and cache it back onto the entry (mutating in place, so
+   * the owning list keeps a stable object reference and the virtual scroll is
+   * not reset).
+   */
+  private async ensureMeticulousShotData() {
+    if (
+      !this.meticulousHistoryData ||
+      this.meticulousHistoryData.data ||
+      !this.meticulousDevice
+    ) {
+      return;
+    }
+    try {
+      const details = await this.meticulousDevice.getHistoryEntryDetails(
+        this.meticulousHistoryData.id,
+      );
+      if (details?.data) {
+        (this.meticulousHistoryData as any).data = details.data;
+      }
+    } catch {
+      // ignore - an empty graph will be rendered
     }
   }
 


### PR DESCRIPTION
Follow-up to #1130. Two issues observed while importing Meticulous shots, with fixes.

## Scroll position resets when loading more shots

**Observed:** The history list loads quickly, but scrolling to the bottom to page in more shots causes the list to jump back to the top, making it difficult to browse beyond the first page.

**Cause:** Shot detail data was loaded in a background loop that rebuilt each entry as a new object and reassigned the history array. The virtual scroll component treats a changed object reference within the already-rendered range as a content change and resets `scrollTop` to 0, so each background update forced the list back to the top.

**Fix:** The history array is now only appended to, preserving existing entry references. Shot detail data is fetched lazily by each graph card as it renders and cached back onto its entry in place, so the array reference used by the virtual scroll no longer changes. As a side effect, detail data is no longer fetched for entries that are never scrolled into view. `choose()` now ensures the selected entry's detail data is loaded before returning it, in case a selection is made before its card has rendered.

## Importing a shot changed the "Choose Profile" setting

**Observed:** Importing a shot overwrote the device's "Choose Profile" selection, which is a separate user-controlled setting.

**Fix:** Importing a shot no longer modifies the "Choose Profile" setting. Instead, the Profile field (`pressure_profile`) is populated from the imported shot's profile name, and only when that brew parameter is active — mirroring the existing field visibility logic, where a preparation using custom parameters overrides the global setting.

## Files changed
- `brew-modal-import-shot-meticulous.component.{ts,html}` — append-only history, lazy per-card detail loading, ensure data on choose
- `graph-display-card.component.ts` — lazily fetch and cache shot detail for its own entry
- `brew-brewing-preparation-device.component.ts` — gate the Profile field on the parameter being active; stop changing the chosen profile

🤖 Generated with [Claude Code](https://claude.com/claude-code)