### PR TITLE
feat(visualizer): include preparation tools in upload payload

### DIFF
--- a/src/classes/visualizer/brewVisualizer.ts
+++ b/src/classes/visualizer/brewVisualizer.ts
@@ -1,5 +1,6 @@
 import { BREW_QUANTITY_TYPES_ENUM } from '../../enums/brews/brewQuantityTypes';
 import { IBrewVisualizer } from '../../interfaces/visualizer/iBrewVisualizer';
+import { IVisualizerPreparationTool } from '../../interfaces/visualizer/iPreparationVisualizer';
 import { BrewFlow } from '../brew/brewFlow';
 import { Config } from '../objectConfig/objectConfig';
 
@@ -43,6 +44,9 @@ export class BrewVisualizer implements IBrewVisualizer {
   public brew_beverage_quantity_type: BREW_QUANTITY_TYPES_ENUM;
 
   public ey: number;
+
+  public used_preparation_tools: IVisualizerPreparationTool[];
+
   constructor() {
     this.grind_size = '';
     this.grind_weight = 0;
@@ -76,5 +80,6 @@ export class BrewVisualizer implements IBrewVisualizer {
     this.vessel_weight = 0;
     this.config = new Config();
     this.ey = 0;
+    this.used_preparation_tools = [];
   }
 }

--- a/src/classes/visualizer/preparationVisualizer.ts
+++ b/src/classes/visualizer/preparationVisualizer.ts
@@ -1,6 +1,9 @@
 import { PREPARATION_STYLE_TYPE } from '../../enums/preparations/preparationStyleTypes';
 import { PREPARATION_TYPES } from '../../enums/preparations/preparationTypes';
-import { IPreparationVisualizer } from '../../interfaces/visualizer/iPreparationVisualizer';
+import {
+  IPreparationVisualizer,
+  IVisualizerPreparationTool,
+} from '../../interfaces/visualizer/iPreparationVisualizer';
 
 export class PreparationVisualizer implements IPreparationVisualizer {
   public name: string;
@@ -8,10 +11,13 @@ export class PreparationVisualizer implements IPreparationVisualizer {
   public style_type: PREPARATION_STYLE_TYPE;
   public type: PREPARATION_TYPES;
 
+  public tools: IVisualizerPreparationTool[];
+
   constructor() {
     this.name = '';
 
     this.type = 'CUSTOM_PREPARATION' as PREPARATION_TYPES;
     this.style_type = undefined;
+    this.tools = [];
   }
 }

--- a/src/classes/visualizer/visualizer.ts
+++ b/src/classes/visualizer/visualizer.ts
@@ -58,6 +58,52 @@ export class Visualizer implements IVisualizer {
     Object.keys(this.preparation).map((_key) => {
       this.preparation[_key] = preparation[_key];
     });
+    // Replace the copied tools array with a stripped-down view so the upload
+    // payload only carries the fields downstream tools actually need
+    // (name), instead of the internal PreparationTool objects with their
+    // UUIDs, archived flags, etc.
+    const rawTools = (preparation as any)?.tools;
+    if (Array.isArray(rawTools)) {
+      this.preparation.tools = rawTools
+        .filter((t) => t && !t.archived)
+        .map((t) => ({ name: t.name }));
+    } else {
+      this.preparation.tools = [];
+    }
+  }
+
+  /**
+   * Populate BrewVisualizer.used_preparation_tools with the names of the
+   * preparation tools that were actually selected for this specific brew.
+   * Beanconqueror stores the selection as UUIDs on the brew; this resolves
+   * them against the preparation's tool catalog into human-readable names.
+   */
+  public mapUsedPreparationTools(
+    brew: Brew | BaristamodeBrew,
+    preparation: Preparation,
+  ) {
+    const selectedUuids = (brew as any)?.method_of_preparation_tools as
+      | string[]
+      | undefined;
+    if (
+      !selectedUuids ||
+      !Array.isArray(selectedUuids) ||
+      selectedUuids.length === 0 ||
+      !Array.isArray((preparation as any)?.tools)
+    ) {
+      this.brew.used_preparation_tools = [];
+      return;
+    }
+    const nameByUuid = new Map<string, string>();
+    for (const tool of (preparation as any).tools) {
+      if (tool?.config?.uuid) {
+        nameByUuid.set(tool.config.uuid, tool.name);
+      }
+    }
+    this.brew.used_preparation_tools = selectedUuids
+      .map((uuid) => nameByUuid.get(uuid))
+      .filter((name): name is string => !!name)
+      .map((name) => ({ name }));
   }
   public mapWater(water: Water) {
     Object.keys(this.water).map((_key) => {

--- a/src/interfaces/visualizer/iBrewVisualizer.ts
+++ b/src/interfaces/visualizer/iBrewVisualizer.ts
@@ -4,6 +4,7 @@
 import { BrewFlow } from '../../classes/brew/brewFlow';
 import { BREW_QUANTITY_TYPES_ENUM } from '../../enums/brews/brewQuantityTypes';
 import { IConfig } from '../objectConfig/iObjectConfig';
+import { IVisualizerPreparationTool } from './iPreparationVisualizer';
 
 export interface IBrewVisualizer {
   // Properties
@@ -116,4 +117,10 @@ export interface IBrewVisualizer {
 
   /*** this is calculcated **/
   ey: number;
+
+  /**
+   * Names of the preparation tools that were actually selected for this brew
+   * (subset of the parent preparation's tool catalog). Empty when none picked.
+   */
+  used_preparation_tools: IVisualizerPreparationTool[];
 }

--- a/src/interfaces/visualizer/iPreparationVisualizer.ts
+++ b/src/interfaces/visualizer/iPreparationVisualizer.ts
@@ -1,6 +1,16 @@
 import { PREPARATION_STYLE_TYPE } from '../../enums/preparations/preparationStyleTypes';
 
+export interface IVisualizerPreparationTool {
+  name: string;
+}
+
 export interface IPreparationVisualizer {
   name: string;
   style_type: PREPARATION_STYLE_TYPE;
+  /**
+   * Names of the preparation tools available on the parent preparation
+   * (e.g. WDT tools, tampers, distributors). Included so downstream tools
+   * such as visualizer.coffee can display the user's tooling context.
+   */
+  tools: IVisualizerPreparationTool[];
 }

--- a/src/services/visualizerService/visualizer-service.service.ts
+++ b/src/services/visualizerService/visualizer-service.service.ts
@@ -121,6 +121,7 @@ export class VisualizerService {
       vS.mapBean(_brew.getBean());
       vS.mapWater(_brew.getWater());
       vS.mapPreparation(_brew.getPreparation());
+      vS.mapUsedPreparationTools(_brew, _brew.getPreparation());
       vS.mapMill(_brew.getMill());
       vS.brewFlow = await this.readFlowProfile(_brew);
       // Put the actual visualizer id into the request if we stored one
@@ -193,6 +194,7 @@ export class VisualizerService {
     try {
       vS.mapBrew(_brew);
       vS.mapPreparation(_brew.getPreparation());
+      vS.mapUsedPreparationTools(_brew, _brew.getPreparation());
 
       delete vS.bean;
       delete vS.water;


### PR DESCRIPTION
## What

Beanconqueror lets users track preparation tools per brew (WDT, tamper, distributor, RDT, etc.) both as a catalog on the `Preparation` and as a per-brew selection via `Brew.method_of_preparation_tools`. Neither made it into the visualizer.coffee upload payload, so downstream analysis tools couldn't see which tools were used for a shot.

This PR forwards that information end-to-end.

## Changes

- `iPreparationVisualizer` / `PreparationVisualizer`: add `tools[]` carrying the non-archived tool **names** available on the parent preparation.
- `iBrewVisualizer` / `BrewVisualizer`: add `used_preparation_tools[]` carrying the tool names actually **selected** for this specific brew.
- `Visualizer.mapPreparation` now replaces the shallow-copied tools with a stripped-down `{name}` view so the upload doesn't leak internal `PreparationTool` objects (UUIDs, archived flags, `Config`).
- `Visualizer.mapUsedPreparationTools`: resolves the brew's tool UUIDs against the preparation catalog into readable names.
- `VisualizerService` calls the new mapper in both normal-brew and baristamode-brew upload paths.

## Why

The Visualizer parser (`Parsers::Beanconqueror` in [miharekar/visualizer](https://github.com/miharekar/visualizer)) stores `@brewdata = json` unchanged, so anything Beanconqueror uploads is automatically retained on the server. All that was missing was the app-side mapping.

Concrete example: a user home-espresso setup that tracks "no-RDT vs 2 puffs RDT" or "MHW Tamper + ARO Spyro Pro" as tool selections per shot can now compare curves against those variables directly from the shot record, without hand-typing them into the notes field.

## Compatibility

- Purely additive on the JSON payload. Existing consumers keep working.
- Empty defaults (`tools: []`, `used_preparation_tools: []`) when nothing is configured, so no behaviour change for users who don't use preparation tools.
- No new dependencies, no schema migration.

## Verification

- `pnpm exec tsc --noEmit -p tsconfig.json` passes clean.
- ESLint on the touched files: no new errors introduced (one pre-existing `no-prototype-builtins` on `mapBrew` and one pre-existing `no-unused-vars` on a legacy import remain, untouched).

## Screenshot of the source data in the app

The brew being modelled below shows the tools I want to see downstream — `MHW Tamper, RDT, ARO Spyro Pro` — that today are dropped on upload:

*(user attaches the screenshot in the PR conversation)*

## Example uploaded payload snippet (after this PR)

```json
{
  "preparation": {
    "name": "Lelit Bianca v3",
    "type": "CUSTOM_PREPARATION",
    "style_type": "ESPRESSO",
    "tools": [
      { "name": "MHW Tamper" },
      { "name": "RDT" },
      { "name": "ARO Spyro Pro" },
      { "name": "Yu Cyclone" }
    ]
  },
  "brew": {
    "…": "…",
    "used_preparation_tools": [
      { "name": "MHW Tamper" },
      { "name": "RDT" },
      { "name": "ARO Spyro Pro" }
    ]
  }
}
```
