### PR TITLE
Always use 'en' as fallback language for missing translations

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -473,10 +473,6 @@ export class AppComponent implements AfterViewInit {
         };
       }
 
-      // Before we update and show messages, we need atleast to set one default language.
-      this._translate.setFallbackLang('en');
-      await this._translate.use('en').toPromise();
-
       if (this.platform.is('capacitor')) {
         try {
           await this.uiExportImportHelper.checkBackup();
@@ -655,7 +651,6 @@ export class AppComponent implements AfterViewInit {
                 settingLanguage = 'en';
               }
               this.uiLog.log(`Setting language: ${settingLanguage}`);
-              this._translate.setFallbackLang(settingLanguage);
               settings.language = settingLanguage;
               await this.uiSettingsStorage.saveSettings(settings);
               await this._translate.use(settingLanguage).toPromise();
@@ -663,7 +658,6 @@ export class AppComponent implements AfterViewInit {
               resolve(undefined);
             } catch (ex) {
               this.uiLog.error('Exception occured when setting language', ex);
-              this._translate.setFallbackLang('en');
               await this._translate.use('en').toPromise();
               moment.locale('en');
               resolve(undefined);
@@ -672,14 +666,12 @@ export class AppComponent implements AfterViewInit {
             this.uiLog.info('Language settings already existing, set language');
             const settingLanguage: string = settings.language;
             this.uiLog.log(`Setting language: ${settingLanguage}`);
-            this._translate.setFallbackLang(settingLanguage);
             await this._translate.use(settingLanguage).toPromise();
             moment.locale(settingLanguage);
             resolve(undefined);
           }
         } catch (ex) {
           this.uiLog.error('Exception occured when setting language', ex);
-          this._translate.setFallbackLang('en');
           settings.language = 'en';
           await this.uiSettingsStorage.saveSettings(settings);
           await this._translate.use('en').toPromise();
@@ -696,7 +688,6 @@ export class AppComponent implements AfterViewInit {
           settings.language !== ''
         ) {
           this.uiLog.info(`Set language from settings: ${settings.language}`);
-          this._translate.setFallbackLang(settings.language);
           await this._translate.use(settings.language).toPromise();
           moment.locale(settings.language);
           resolve(undefined);
@@ -704,7 +695,6 @@ export class AppComponent implements AfterViewInit {
           this.uiLog.info(
             `Set default language from settings, because no settings set: en `,
           );
-          this._translate.setFallbackLang('en');
           settings.language = 'en';
           await this.uiSettingsStorage.saveSettings(settings);
           await this._translate.use('en').toPromise();

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -760,7 +760,6 @@ export class SettingsPage {
   }
 
   public setLanguage(): void {
-    this.translate.setFallbackLang(this.settings.language);
     this.translate.use(this.settings.language);
     this.uiAnalytics.trackEvent(
       SETTINGS_TRACKING.TITLE,

--- a/src/main.ts
+++ b/src/main.ts
@@ -49,6 +49,11 @@ bootstrapApplication(AppComponent, {
     AndroidPermissions,
     provideHttpClient(withInterceptorsFromDi()),
     provideTranslateService({
+      // The app will set the user-preferred language later, this is just a default
+      lang: 'en',
+      // The app will never change the fallback language
+      fallbackLang: 'en',
+
       loader: provideTranslateHttpLoader({
         prefix: './assets/i18n/',
         suffix: '.json',


### PR DESCRIPTION
This ensures that a user never sees raw translation keys as long as an English translation exists.

While I was at it, I also set the startup language to 'en' in the config instead of programmatically on startup. The app will still load the user-preferred language at a later point.