### PR TITLE
#1151 - Retry AI bean import without temperature when the model rejects it

### DIFF
--- a/src/services/aiBeanImport/__tests__/cloud-llm-communication.service.spec.ts
+++ b/src/services/aiBeanImport/__tests__/cloud-llm-communication.service.spec.ts
@@ -2,6 +2,7 @@ import { AI_PROVIDER_ENUM } from '../../../enums/settings/aiProvider';
 import {
   CloudLLMConfig,
   CloudLLMMessage,
+  resetTemperatureSupportCache,
   sendCloudLLMPrompt,
 } from '../cloud-llm-communication.service';
 
@@ -40,6 +41,10 @@ describe('cloud-llm-communication.service', () => {
 
   beforeEach(() => {
     fetchSpy = spyOn(globalThis, 'fetch');
+    // The temperature-support cache is module-level state that persists
+    // across tests; reset it so combinations remembered by one test do
+    // not leak into another.
+    resetTemperatureSupportCache();
   });
 
   // ── Request building per provider ──────────────────────────────────
@@ -415,6 +420,88 @@ describe('cloud-llm-communication.service', () => {
       await expectAsync(sendCloudLLMPrompt(config, messages)).toBeRejectedWith(
         jasmine.any(TypeError),
       );
+    });
+  });
+
+  // ── Temperature compatibility ──────────────────────────────────────
+
+  describe('temperature compatibility', () => {
+    // WHY: The newest models (Claude Sonnet 5, OpenAI GPT-5.x, ...) reject
+    // the `temperature` parameter with a 400. We send it best-effort, drop
+    // it and retry once when rejected, and remember the model so later
+    // requests skip it.
+
+    const temperatureRejection = () =>
+      mockFetchResponse(
+        {
+          error: {
+            type: 'invalid_request_error',
+            message: '`temperature` is deprecated for this model.',
+          },
+        },
+        400,
+      );
+
+    const success = (model: string) =>
+      mockFetchResponse({
+        choices: [{ message: { content: 'response' } }],
+        model,
+      });
+
+    it('should drop temperature and retry when rejected with a 400', async () => {
+      // Arrange
+      const config = createConfig({ model: 'gpt-5.6-terra' });
+      fetchSpy.and.returnValues(
+        Promise.resolve(temperatureRejection()),
+        Promise.resolve(success('gpt-5.6-terra')),
+      );
+
+      // Act
+      const result = await sendCloudLLMPrompt(config, messages);
+
+      // Assert
+      expect(result.content).toBe('response');
+      expect(fetchSpy).toHaveBeenCalledTimes(2);
+
+      // First attempt includes temperature, retry omits it.
+      const firstBody = JSON.parse(fetchSpy.calls.argsFor(0)[1].body);
+      const retryBody = JSON.parse(fetchSpy.calls.argsFor(1)[1].body);
+      expect(firstBody.temperature).toBe(0.1);
+      expect(retryBody.temperature).toBeUndefined();
+    });
+
+    it('should remember the model and skip temperature on later requests', async () => {
+      // Arrange: first request rejects then succeeds, populating the cache.
+      const config = createConfig({ model: 'gpt-5.6-terra' });
+      fetchSpy.and.returnValues(
+        Promise.resolve(temperatureRejection()),
+        Promise.resolve(success('gpt-5.6-terra')),
+      );
+      await sendCloudLLMPrompt(config, messages);
+
+      // Act: a second request to the same model.
+      fetchSpy.calls.reset();
+      fetchSpy.and.returnValue(Promise.resolve(success('gpt-5.6-terra')));
+      await sendCloudLLMPrompt(config, messages);
+
+      // Assert: no temperature sent, and no retry needed (single call).
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+      const body = JSON.parse(fetchSpy.calls.argsFor(0)[1].body);
+      expect(body.temperature).toBeUndefined();
+    });
+
+    it('should not retry on a 400 unrelated to temperature', async () => {
+      // Arrange
+      const config = createConfig({ model: 'gpt-4o' });
+      fetchSpy.and.returnValue(
+        Promise.resolve(
+          mockFetchResponse({ error: { message: 'invalid model' } }, 400),
+        ),
+      );
+
+      // Act & Assert
+      await expectAsync(sendCloudLLMPrompt(config, messages)).toBeRejected();
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/services/aiBeanImport/cloud-llm-communication.service.ts
+++ b/src/services/aiBeanImport/cloud-llm-communication.service.ts
@@ -28,7 +28,11 @@ export interface CloudLLMResponse {
 interface ProviderProtocol {
   readonly url: string;
   readonly headers: Record<string, string>;
-  buildRequestBody(model: string, messages: CloudLLMMessage[]): object;
+  buildRequestBody(
+    model: string,
+    messages: CloudLLMMessage[],
+    includeTemperature: boolean,
+  ): object;
   parseResponse(body: unknown): CloudLLMResponse;
 }
 
@@ -65,11 +69,19 @@ class OpenAICompatibleProtocol implements ProviderProtocol {
     };
   }
 
-  buildRequestBody(model: string, messages: CloudLLMMessage[]): object {
+  buildRequestBody(
+    model: string,
+    messages: CloudLLMMessage[],
+    includeTemperature: boolean,
+  ): object {
     return {
       model,
       messages: messages.map((m) => ({ role: m.role, content: m.content })),
-      temperature: 0.1,
+      // A low temperature keeps extraction deterministic, but the newest
+      // models (e.g. OpenAI GPT-5.x) reject the parameter outright. It is
+      // dropped and the request retried when the API rejects it — see
+      // sendCloudLLMPrompt.
+      ...(includeTemperature ? { temperature: 0.1 } : {}),
     };
   }
 
@@ -105,13 +117,21 @@ class AnthropicProtocol implements ProviderProtocol {
     };
   }
 
-  buildRequestBody(model: string, messages: CloudLLMMessage[]): object {
+  buildRequestBody(
+    model: string,
+    messages: CloudLLMMessage[],
+    includeTemperature: boolean,
+  ): object {
     const systemMsg = messages.find((m) => m.role === 'system');
     const userMsgs = messages.filter((m) => m.role !== 'system');
     return {
       model,
       max_tokens: 4096,
-      temperature: 0.1,
+      // A low temperature keeps extraction deterministic, but the newest
+      // models (e.g. Claude Sonnet 5, Opus 4.7+) reject the parameter
+      // outright. It is dropped and the request retried when the API
+      // rejects it — see sendCloudLLMPrompt.
+      ...(includeTemperature ? { temperature: 0.1 } : {}),
       system: systemMsg?.content ?? '',
       messages: userMsgs.map((m) => ({ role: m.role, content: m.content })),
     };
@@ -177,21 +197,62 @@ function createProtocol(config: CloudLLMConfig): ProviderProtocol {
   }
 }
 
+// ── Temperature compatibility tracking ───────────────────────────────
+//
+// The newest model generations (Claude Sonnet 5 / Opus 4.7+, OpenAI
+// GPT-5.x, ...) have removed the `temperature` sampling parameter and
+// reject any request that sends it with an HTTP 400. Rather than maintain
+// a hard-coded model list, we send temperature best-effort and, when a
+// model rejects it, remember that provider+model so subsequent requests
+// skip it. This keeps the deterministic low temperature on every model
+// that honours it and self-heals for models that do not.
+
+const temperatureUnsupportedModels = new Set<string>();
+
+/** Cache key identifying a provider+model combination. */
+function providerModelKey(config: CloudLLMConfig): string {
+  return `${config.provider}:${config.model}`;
+}
+
+/** HTTP error carrying the status and raw body for post-hoc inspection. */
+class CloudLLMHttpError extends Error {
+  constructor(
+    readonly status: number,
+    readonly body: string,
+  ) {
+    super(`Cloud LLM API error (${status}): ${body}`);
+    this.name = 'CloudLLMHttpError';
+  }
+}
+
+/** True when an error is a 400 that names the temperature parameter. */
+function isTemperatureRejection(error: unknown): boolean {
+  return (
+    error instanceof CloudLLMHttpError &&
+    error.status === 400 &&
+    /temperature/i.test(error.body)
+  );
+}
+
+/** Clears the temperature-support cache. Test-only. */
+export function resetTemperatureSupportCache(): void {
+  temperatureUnsupportedModels.clear();
+}
+
 // ── Public API ───────────────────────────────────────────────────────
 
-/**
- * Send a prompt to a cloud LLM provider and return the response.
- *
- * Protocol details (URL, headers, body format, response parsing) are
- * handled by provider-specific config classes. This function handles
- * only fetch, timeout, and error handling.
- */
-export async function sendCloudLLMPrompt(
-  config: CloudLLMConfig,
+/** Perform a single request attempt: fetch, timeout, and error handling. */
+async function sendOnce(
+  protocol: ProviderProtocol,
+  model: string,
   messages: CloudLLMMessage[],
+  includeTemperature: boolean,
 ): Promise<CloudLLMResponse> {
-  const protocol = createProtocol(config);
-  const requestBody = protocol.buildRequestBody(config.model, messages);
+  const requestBody = protocol.buildRequestBody(
+    model,
+    messages,
+    includeTemperature,
+  );
 
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), 30000);
@@ -207,7 +268,7 @@ export async function sendCloudLLMPrompt(
 
     if (!response.ok) {
       const errorBody = await response.text().catch(() => '');
-      throw new Error(`Cloud LLM API error (${response.status}): ${errorBody}`);
+      throw new CloudLLMHttpError(response.status, errorBody);
     }
 
     const body: unknown = await response.json();
@@ -219,6 +280,35 @@ export async function sendCloudLLMPrompt(
       throw new Error('Cloud LLM request timed out after 30 seconds');
     }
 
+    throw error;
+  }
+}
+
+/**
+ * Send a prompt to a cloud LLM provider and return the response.
+ *
+ * Protocol details (URL, headers, body format, response parsing) are
+ * handled by provider-specific config classes. This function handles
+ * fetch, timeout, error handling, and the temperature-rejection retry:
+ * if a model rejects `temperature` with a 400, the parameter is dropped,
+ * the request is retried once, and the provider+model is remembered so
+ * future requests skip it.
+ */
+export async function sendCloudLLMPrompt(
+  config: CloudLLMConfig,
+  messages: CloudLLMMessage[],
+): Promise<CloudLLMResponse> {
+  const protocol = createProtocol(config);
+  const key = providerModelKey(config);
+  const includeTemperature = !temperatureUnsupportedModels.has(key);
+
+  try {
+    return await sendOnce(protocol, config.model, messages, includeTemperature);
+  } catch (error) {
+    if (includeTemperature && isTemperatureRejection(error)) {
+      temperatureUnsupportedModels.add(key);
+      return await sendOnce(protocol, config.model, messages, false);
+    }
     throw error;
   }
 }


### PR DESCRIPTION
## Problem

The AI bean import feature fails outright on the newest model generations. Selecting **Claude Sonnet 5** (Anthropic) or **GPT-5.x** (OpenAI) returns:

```json
{ "error": { "type": "invalid_request_error", "message": "`temperature` is deprecated for this model." } }
```

Fixes #1151 (OpenAI GPT-5.x) and the same failure reported for Claude Sonnet 5.

## Root cause

`cloud-llm-communication.service.ts` (added in #1061) hard-codes `temperature: 0.1` in every request body — in both the OpenAI-compatible and Anthropic protocols. The latest models (Claude Sonnet 5 / Opus 4.7+, OpenAI GPT-5.x) have **removed** the `temperature` sampling parameter and reject any request that includes it with an HTTP 400. Older models (GPT-4.x, Gemini, Mistral, Claude Sonnet ≤4.6) still accept it, which is why the feature works on those.

## Fix

Send `temperature` best-effort and adapt when it is rejected, rather than maintaining a hard-coded model list:

1. Attempt the request with `temperature: 0.1` (unless the model is already known to reject it).
2. If it fails with an HTTP **400 whose body names `temperature`**, drop the parameter, retry once, and remember that `provider:model` combination for the rest of the session.
3. Any other error propagates unchanged.

This keeps the deterministic low temperature on every model that honours it and self-heals for models that do not — including future ones — with no model-name matrix to maintain.

## Notes

- Both protocols now build the body with `includeTemperature`; the retry state is a session-level `Set<string>` keyed by `provider:model`.
- A `CloudLLMHttpError` carries the status + raw body for precise detection while keeping the existing `Cloud LLM API error (…)` message unchanged, so existing error handling/tests are unaffected.
- Follow-up (not in this PR): the same adaptive path could carry a low `reasoning_effort` / `output_config.effort` for reasoning models, since factual extraction does not benefit from deep reasoning.

## Testing

- `pnpm test` — all unit tests pass, including 3 new cases: drop-and-retry on a temperature 400, remembering the model so later requests skip temperature on the first attempt, and no-retry on an unrelated 400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
