### PR TITLE
feat: Decouple Meticulous shot import from the chosen profile

### DIFF
--- a/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
+++ b/src/app/brew/brew-modal-import-shot-meticulous/brew-modal-import-shot-meticulous.component.ts
@@ -69,7 +69,6 @@ export class BrewModalImportShotMeticulousComponent
   public static COMPONENT_ID: string = 'brew-modal-import-shot-meticulous';
 
   @Input() public meticulousDevice: MeticulousDevice;
-  @Input() public profileFilter: string | undefined;
   public radioSelection: string;
   public history: any[] = [];
   public chartWidth = 0;
@@ -112,10 +111,7 @@ export class BrewModalImportShotMeticulousComponent
   private async readHistory() {
     await this.uiAlert.showLoadingSpinner();
     try {
-      const results = await this.meticulousDevice?.getHistory(
-        undefined,
-        this.profileFilter,
-      );
+      const results = await this.meticulousDevice?.getHistory();
       this.history = results ?? [];
       this.lastEntryTime = this.history[this.history.length - 1]?.time;
       this.hasMore = this.history.length >= MeticulousDevice.PAGE_SIZE;
@@ -141,12 +137,8 @@ export class BrewModalImportShotMeticulousComponent
     }
     this.isLoadingMore = true;
     try {
-      /**
-       * Search all profiles everytime
-       */
       const results = await this.meticulousDevice?.getHistory(
         this.lastEntryTime,
-        '',
       );
       const allResults = results ?? [];
       const newEntries = allResults.filter(

--- a/src/assets/i18n/en.json
+++ b/src/assets/i18n/en.json
@@ -1379,6 +1379,7 @@
     "IGNORE_ANOMALY_VALUES_DESCRIPTION": "Activating this, results into a graph which will be one second behind",
     "SAVE_LOGFILES_TO_NOTES_FROM_MACHINE": "Save the machine logs when saving a brew",
     "IMPORT_SHOT_FROM_METICULOUS": "Import a shot",
+    "OR": "or",
     "BEANS_IMPORTED_SUCCESSFULLY_DESCRIPTION": "All found entries in the excel list, have been transformed into new beans, enjoy a tasty brew!",
     "IMPORT_UNSUCCESSFULLY": "Import not successful",
     "BEAN_LIST": "Bean list",

--- a/src/classes/preparationDevice/meticulous/meticulousDevice.ts
+++ b/src/classes/preparationDevice/meticulous/meticulousDevice.ts
@@ -97,12 +97,9 @@ export class MeticulousDevice extends PreparationDevice {
     if (typeof cordova !== 'undefined') {
     }
   }
-  public async getHistory(
-    endDate?: number,
-    profileFilter?: string,
-  ): Promise<HistoryListingEntry[]> {
+  public async getHistory(endDate?: number): Promise<HistoryListingEntry[]> {
     const params: any = {
-      query: profileFilter ?? '',
+      query: '',
       ids: [],
       order_by: ['date'],
       sort: 'desc',

--- a/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.html
+++ b/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.html
@@ -95,7 +95,14 @@
         <ion-item lines="none">
           <span class="ion-title ion-padding-top">{{ "PREPARATION_DEVICE.TYPE_METICULOUS.TITLE" | translate }}</span>
         </ion-item>
-        <ion-item lines="inset">
+        <ion-item (click)="importShotFromMeticulous()" button tappable lines="none">
+          <ion-icon name="cloud-download-outline" slot='start'></ion-icon>
+          <span>{{ "IMPORT_SHOT_FROM_METICULOUS" | translate }}</span>
+        </ion-item>
+        <div class="or-separator">
+          <span>{{ "OR" | translate }}</span>
+        </div>
+        <ion-item lines="none">
           <ion-select [label]="'PREPARATION_DEVICE.TYPE_METICULOUS.CHOOSE_PROFILE' | translate"
                       label-placement="stacked"
                       [interfaceOptions]="customXeniaOptions"
@@ -110,11 +117,6 @@
               </ion-select-option>
             }
           </ion-select>
-        </ion-item>
-        <hr/>
-        <ion-item (click)="importShotFromMeticulous()" button tappable>
-          <ion-icon name="cloud-download-outline" slot='start'></ion-icon>
-          <span>{{ "IMPORT_SHOT_FROM_METICULOUS" | translate }}</span>
         </ion-item>
       </ion-card>
   } @else if (isSanremoYOUDevice(preparationDevice)) {

--- a/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.scss
+++ b/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.scss
@@ -5,6 +5,23 @@
     margin-right: 16px;
   }
 
+  /* Compact "- or -" divider between two alternative actions inside a card */
+  .or-separator {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin: 2px 16px;
+    color: var(--ion-color-medium);
+    font-size: 12px;
+
+    &::before,
+    &::after {
+      content: '';
+      flex: 1;
+      border-top: 1px solid var(--ion-color-light-shade);
+    }
+  }
+
   ion-col.active {
     color: black !important;
     ion-card {

--- a/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.ts
+++ b/src/components/brews/brew-brewing-preparation-device/brew-brewing-preparation-device.component.ts
@@ -911,20 +911,14 @@ export class BrewBrewingPreparationDeviceComponent
 
   public async importShotFromMeticulous() {
     const meticulousDevice = this.preparationDevice as MeticulousDevice;
-    const chosenProfileId = (
-      this.data.preparationDeviceBrew.params as MeticulousParams
-    )?.chosenProfileId;
-    const profileFilter = chosenProfileId
-      ? meticulousDevice.getProfiles().find((p) => p.id === chosenProfileId)
-          ?.name
-      : undefined;
 
+    // The chosen profile is only used for the brew itself, it deliberately does
+    // not narrow down the shot history: users expect to see every shot here.
     const modal = await this.modalController.create({
       component: BrewModalImportShotMeticulousComponent,
       id: BrewModalImportShotMeticulousComponent.COMPONENT_ID,
       componentProps: {
         meticulousDevice,
-        profileFilter,
       },
     });
 


### PR DESCRIPTION
Follow-up to #1130 / #1141, addressing the profile-scoped shot history noted there and [discussed on Discord](https://discord.com/channels/1260311692924162150/1271773339878162522/1528810599880982599) ("I think seeing all would be the better solution in the end").

## Shot import no longer filters by the chosen profile

**Observed:** Choosing a profile first caused "Import a shot" to only offer shots pulled with that profile. Nothing in the UI presents the profile select as a filter, so shots that exist on the machine simply appear to be missing.

**Cause:** The profile select underneath the "Meticulous Machine" section exists to set the profile to use live in the "While Brewing" section. Its value was additionally being resolved to a profile name and passed to the import modal as `profileFilter`, which fed the history search `query`.

76629e05 already removed the filter from the paging call, but the initial load still passed it. That left the two inconsistent: the first page was profile-scoped while every page loaded on scroll was not, so the list would start narrow and then widen as you scrolled.

**Fix:** The import modal no longer receives a profile filter at all, so both the initial load and paging list every recent shot. The now-unused `profileFilter` parameter is removed from `MeticulousDevice.getHistory()` so the coupling cannot be reintroduced by accident. Choosing a profile still does exactly what it did before for the brew itself — it is simply no longer entangled with import.

## Reordered the section to show the two are independent

With the filtering gone, the ordering was still implying a sequence: pick a profile, then import within it. "Import a shot" now comes first, followed by a compact `or` divider, then "Choose profile".

```
  Meticulous Machine

  ⬇  Import a shot

  ─────────── or ───────────

  Choose profile
  [ No Profile            ▾ ]
```

### Screenshot

<img width="642" height="219" alt="image" src="https://github.com/user-attachments/assets/b74bb2ed-044e-49a3-85e3-bb5684889658" />


The divider replaces the previous full-width `<hr/>` and is styled with rules on both sides of a muted 12px label. It is deliberately not uppercased: every other `text-transform` in the app cancels uppercase rather than adding it (`ion-button` is set to `inherit` specifically to undo Ionic's Material-mode all-caps), and CSS uppercasing applies blindly to translated strings, which is locale-sensitive. The new `OR` key is added to `en.json` only, matching how new strings are handled elsewhere.

## Files changed

- `brew-brewing-preparation-device.component.ts` — stop resolving and passing `profileFilter` to the import modal
- `brew-modal-import-shot-meticulous.component.ts` — drop the `profileFilter` input; initial load now matches paging
- `meticulousDevice.ts` — remove the unused `profileFilter` parameter from `getHistory()`
- `brew-brewing-preparation-device.component.{html,scss}` — reorder the two actions, add the `or` divider
- `en.json` — new `OR` key

Verified with `tsc --noEmit` and `ng build` (no new errors or warnings on the touched files); lint and prettier report no new issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
