### PR TITLE
Add ETI Ltd BlueDot temperature device

### DIFF
--- a/src/classes/devices/etiBlueDotTemperature.ts
+++ b/src/classes/devices/etiBlueDotTemperature.ts
@@ -1,0 +1,97 @@
+import { PeripheralData } from './ble.types';
+import { Logger } from './common/logger';
+import {
+  celciusToFahrenheit,
+  fahrenheitToCelcius,
+  Temperature,
+  TemperatureDevice,
+} from './temperatureBluetoothDevice';
+
+declare var ble: any;
+
+export class ETIBlueDotTemperature extends TemperatureDevice {
+  public static DEVICE_NAME = 'BLUEDOT';
+  public static TEMPERATURE_SERVICE_UUID =
+    'bb56aab0-4111-40cf-963b-4a4450ea0822';
+  public static TEMPERATURE_CHAR_UUID =
+    '783f2991-23e0-4bdc-ac16-78601bd84b39';
+
+  private logger: Logger;
+
+  constructor(data: PeripheralData) {
+    super(data);
+    this.connect();
+    this.logger = new Logger('ETIBlueDotTemperatureSensor');
+  }
+
+  public static test(device: any): boolean {
+    return (
+      device &&
+      device.name &&
+      device.name.toUpperCase().includes(ETIBlueDotTemperature.DEVICE_NAME)
+    );
+  }
+
+  public connect() {
+    this.attachNotification();
+  }
+
+  public disconnect() {
+    this.deattachNotification();
+  }
+
+  private attachNotification() {
+    ble.startNotification(
+      this.device_id,
+      ETIBlueDotTemperature.TEMPERATURE_SERVICE_UUID,
+      ETIBlueDotTemperature.TEMPERATURE_CHAR_UUID,
+      async (_data: any) => {
+        this.parseStatusUpdate(_data);
+      },
+      (_data: any) => {},
+    );
+  }
+
+  /**
+   * ETI BlueDOT Temperature data is a Little Endian signed 32-bit integer.
+   * The first byte of the packet is a header byte, so the temperature
+   * starts at byte 1.
+   */  
+  private parseStatusUpdate(temperatureRawStatus: any) {
+    const temperature = new Int32Array(
+      temperatureRawStatus.slice(1, 5),
+    )[0];
+
+    const isFahrenheit =
+      new Uint8Array(temperatureRawStatus.slice(11, 12))[0] === 1;
+
+    const temperatureCelcius = isFahrenheit
+      ? fahrenheitToCelcius(temperature)
+      : temperature;
+
+    this.logger.log(
+      'temperatureRawStatus received is: ' + temperatureRawStatus,
+    );
+
+    this.logger.log(
+      'temperature is: ' +
+        temperature +
+        (isFahrenheit ? ' F' : ' C') +
+        ', converted temperature is: ' +
+        temperatureCelcius +
+        ' C',
+    );
+
+    this.setTemperature(temperatureCelcius, temperatureRawStatus);
+  }
+
+  private deattachNotification() {
+    ble.stopNotification(
+      this.device_id,
+      ETIBlueDotTemperature.TEMPERATURE_SERVICE_UUID,
+      ETIBlueDotTemperature.TEMPERATURE_CHAR_UUID,
+      (e: any) => {},
+      (e: any) => {},
+    );
+  }
+}

--- a/src/classes/devices/index.ts
+++ b/src/classes/devices/index.ts
@@ -16,6 +16,7 @@ import { DiyPythonCoffeeScale } from './diyPythonCoffeeScale';
 import { DiyRustCoffeeScale } from './diyRustCoffeeScale';
 import { EspressiScale } from './espressiScale';
 import { ETITemperature } from './etiTemperature';
+import { ETIBlueDotTemperature } from './etiBlueDotTemperature';
 import { EurekaPrecisaScale } from './eurekaPrecisaScale';
 import { FelicitaScale } from './felicitaScale';
 import { FutulaScale } from './futulaScale';
@@ -136,6 +137,8 @@ export function makeTemperatureDevice(
   switch (type) {
     case TemperatureType.ETI:
       return new ETITemperature(data);
+    case TemperatureType.ETIBLUEDOT:
+      return new ETIBlueDotTemperature(data);
     case TemperatureType.BASICGRILL:
       return new BasicGrillThermometer(data);
     case TemperatureType.MEATER:

--- a/src/classes/devices/types.ts
+++ b/src/classes/devices/types.ts
@@ -40,6 +40,7 @@ export enum PressureType {
 
 export enum TemperatureType {
   ETI = 'ETI',
+  ETIBLUEDOT = 'ETIBLUEDOT',
   BASICGRILL = 'BASICGRILL',
   MEATER = 'MEATER',
   COMBUSTION = 'COMBUSTION',

--- a/src/services/coffeeBluetoothDevices/coffee-bluetooth-devices.service.ts
+++ b/src/services/coffeeBluetoothDevices/coffee-bluetooth-devices.service.ts
@@ -13,6 +13,7 @@ import { Logger } from 'src/classes/devices/common/logger';
 import { DifluidMicrobalance } from 'src/classes/devices/difluidMicrobalance';
 import { DiFluidR2Refractometer } from 'src/classes/devices/difluidR2Refractometer';
 import { ETITemperature } from 'src/classes/devices/etiTemperature';
+import { ETIBlueDotTemperature } from 'src/classes/devices/etiBlueDotTemperature';
 import { MeaterThermometer } from 'src/classes/devices/meaterThermometer';
 import { PressureDevice } from 'src/classes/devices/pressureBluetoothDevice';
 import { PrsPressure } from 'src/classes/devices/prsPressure';
@@ -520,6 +521,7 @@ export class CoffeeBluetoothDevicesService {
         (scanDevice) => {
           if (
             ETITemperature.test(scanDevice) ||
+            ETIBlueDotTemperature.test(scanDevice) ||
             BasicGrillThermometer.test(scanDevice) ||
             MeaterThermometer.test(scanDevice) ||
             CombustionThermometer.test(scanDevice) ||
@@ -838,6 +840,12 @@ export class CoffeeBluetoothDevicesService {
     if (ETITemperature.test(deviceTemperature)) {
       this.logger.log('BleManager - We found a ETI Ltd Thermometer device ');
       return { id: deviceTemperature.id, type: TemperatureType.ETI };
+    } else if (ETIBlueDotTemperature.test(deviceTemperature)) {
+      this.logger.log('BleManager - We found a ETI Ltd BlueDOT Thermometer device ');
+      return {
+        id: deviceTemperature.id,
+        type: TemperatureType.ETIBLUEDOT,
+      };
     } else if (BasicGrillThermometer.test(deviceTemperature)) {
       this.logger.log(
         'BleManager - We found a Basic Grill Thermometer device ',


### PR DESCRIPTION
## Description

Hi! So I bought the [ETI BlueDot](https://thermometer.co.uk/bluetooth-thermometers/1423-bluedot-bluetooth-thermometer.html)  as ETI Ltd devices are listed as compatible, but turns out it isn't. So this is to add support to it.

For reference, this is what I managed to reverse engineer from the packet structure:

Offset | Size | Type | Meaning
-- | -- | -- | --
0 | 1 | uint8 | Probe/device status
1–4 | 4 | int32 LE | Current temperature
5–8 | 4 | int32 LE | High alarm threshold
9 | 1 | uint8 | Unknown
10 | 1 | uint8 | High alarm enabled: 0 = ON, 1 = OFF
11 | 1 | uint8 | Unit: 0 = °C, 1 = °F
12–13 | 2 | bytes | Unknown
14–18 | 5 | bytes | Device address
19 | 1 | uint8 | Alarm/event triggered: 0 = inactive, 1 = triggered

I made some assumptions that could need rectification:
- BlueDOT uses a different protocol from Thermapen Blue, so it should be in a separate file from `etiTemperature.ts`.
- `etiBlueDotTemperature` and other name I used are the desired naming convention.
- Beanconqueror always expects the temperature in Celsius, so when the BlueDOT is in Fahrenheit mode, the temperature is converted. In case that Beanconqueror is unit agnostic and the registered temperature in the app should match the one shown in the display of the thermometer, please let me know.
- Fahrenheit to Celsius conversion should be made with `celciusToFahrenheit()` from `temperatureBluetoothDevice.ts`, and all references to Celsius degrees should be named "Celcius".

This has been developed and tested with a BlueDOT device and a physical Android device, and it's currently working. I'm leaving this as draft as I want to do some further testing, and in case that changes are requested, specially if one of my assumptions is wrong.

## GitHub Issue / Discussion Reference

Related: #517 

## AI Assistance Disclosure

I have to admit that when I started, I thought it was going to be an easy fix and not a completely different protocol, something that I didn't knew how to do, so I had to rely on AI.

### AI Usage Level

- [ ] Completely on my own (0% AI)
- [ ] Assisted by AI (up to 50% AI)
- [X] Completely or mostly generated by AI (50% - 100% AI)

### AI Provider / Tool

- **ChatGPT**

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] Other (please describe):

## Screenshots / Videos (if applicable)

<img width="720" height="483" alt="Screenshot_2026-08-25-23-23-29-459-edit_com beanconqueror app" src="https://github.com/user-attachments/assets/eb6a0b05-8451-46a0-9d63-5fa5fa41570c" />
<img width="720" height="342" alt="Screenshot_2026-08-25-23-24-49-399-edit_com beanconqueror app" src="https://github.com/user-attachments/assets/daef9ba5-a870-4d42-b028-afc5a9610923" />
<img width="720" height="1600" alt="Screenshot_2026-08-25-23-26-28-728_com beanconqueror app" src="https://github.com/user-attachments/assets/ed560e8a-605e-4398-8b29-a9d5c7caa2cc" />

## Tested Platforms

- [X] Android
- [ ] iOS
- [ ] Web

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings or lint errors

EDIT 26/08/2026: Updated table of packet structure