### PR TITLE
Fixing Date Locales in Home and Statistics

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -654,7 +654,7 @@ export class AppComponent implements AfterViewInit {
               settings.language = settingLanguage;
               await this.uiSettingsStorage.saveSettings(settings);
               await this._translate.use(settingLanguage).toPromise();
-              moment.locale(settingLanguage);
+              this.uiHelper.setMomentLocale(settingLanguage);
               resolve(undefined);
             } catch (ex) {
               this.uiLog.error('Exception occured when setting language', ex);
@@ -667,7 +667,7 @@ export class AppComponent implements AfterViewInit {
             const settingLanguage: string = settings.language;
             this.uiLog.log(`Setting language: ${settingLanguage}`);
             await this._translate.use(settingLanguage).toPromise();
-            moment.locale(settingLanguage);
+            this.uiHelper.setMomentLocale(settingLanguage);
             resolve(undefined);
           }
         } catch (ex) {
@@ -689,7 +689,7 @@ export class AppComponent implements AfterViewInit {
         ) {
           this.uiLog.info(`Set language from settings: ${settings.language}`);
           await this._translate.use(settings.language).toPromise();
-          moment.locale(settings.language);
+          this.uiHelper.setMomentLocale(settings.language);
           resolve(undefined);
         } else {
           this.uiLog.info(
@@ -698,7 +698,7 @@ export class AppComponent implements AfterViewInit {
           settings.language = 'en';
           await this.uiSettingsStorage.saveSettings(settings);
           await this._translate.use('en').toPromise();
-          moment.locale(settings.language);
+          this.uiHelper.setMomentLocale(settings.language);
           resolve(undefined);
         }
       }

--- a/src/app/settings/settings.page.ts
+++ b/src/app/settings/settings.page.ts
@@ -47,7 +47,6 @@ import { Directory, Filesystem } from '@capacitor/filesystem';
 import { Geolocation } from '@capacitor/geolocation';
 import { FilePicker } from '@capawesome/capacitor-file-picker';
 import { TranslatePipe, TranslateService } from '@ngx-translate/core';
-import moment from 'moment';
 import { Subject } from 'rxjs';
 import { debounceTime, distinctUntilChanged } from 'rxjs/operators';
 
@@ -767,7 +766,7 @@ export class SettingsPage {
       this.settings.language,
     );
     this.uiSettingsStorage.saveSettings(this.settings);
-    moment.locale(this.settings.language);
+    this.uiHelper.setMomentLocale(this.settings.language);
   }
 
   public async import(): Promise<void> {

--- a/src/services/uiHelper.ts
+++ b/src/services/uiHelper.ts
@@ -139,6 +139,21 @@ export class UIHelper {
     return StorageClass.getUnixTimestamp();
   }
 
+  public setMomentLocale(locale: string): string {
+    const normalizedLocale = locale?.toLowerCase();
+    const availableLocale = moment
+      .locales()
+      .find(
+        (loadedLocale) =>
+          loadedLocale.toLowerCase() === normalizedLocale ||
+          loadedLocale.toLowerCase().split('-')[0] === normalizedLocale,
+      );
+    const selectedLocale = availableLocale ?? 'en';
+
+    moment.locale(selectedLocale);
+    return selectedLocale;
+  }
+
   public isToday(_unix: number): boolean {
     return moment.unix(moment().unix()).isSame(moment.unix(_unix), 'd');
   }

--- a/src/services/uiHelper.ts
+++ b/src/services/uiHelper.ts
@@ -14,6 +14,7 @@ import 'moment/locale/fr';
 import 'moment/locale/id';
 import 'moment/locale/pl';
 import 'moment/locale/nl';
+import 'moment/locale/nb';
 import 'moment/locale/pt';
 import 'moment/locale/el';
 import 'moment/locale/cs';
@@ -139,14 +140,21 @@ export class UIHelper {
     return StorageClass.getUnixTimestamp();
   }
 
+  /**
+   * Set the moment locale based on the provided locale string.
+   * If the provided locale is 'no' (Norwegian), it will be fixed to 'nb' for moment.js.
+   * If the provided locale is not available, it will default to 'en'.
+   * @param locale The locale string to get for moment.js.
+   */
   public setMomentLocale(locale: string): string {
     const normalizedLocale = locale?.toLowerCase();
+    const momentLocale = normalizedLocale === 'no' ? 'nb' : normalizedLocale;
     const availableLocale = moment
       .locales()
       .find(
         (loadedLocale) =>
-          loadedLocale.toLowerCase() === normalizedLocale ||
-          loadedLocale.toLowerCase().split('-')[0] === normalizedLocale,
+          loadedLocale.toLowerCase() === momentLocale ||
+          loadedLocale.toLowerCase().split('-')[0] === momentLocale,
       );
     const selectedLocale = availableLocale ?? 'en';
 

--- a/src/services/uiHelper.ts
+++ b/src/services/uiHelper.ts
@@ -6,6 +6,17 @@ import { Clipboard } from '@capacitor/clipboard';
 import moment from 'moment';
 
 import 'moment/locale/de';
+import 'moment/locale/it';
+import 'moment/locale/es';
+import 'moment/locale/tr';
+import 'moment/locale/zh-cn';
+import 'moment/locale/fr';
+import 'moment/locale/id';
+import 'moment/locale/pl';
+import 'moment/locale/nl';
+import 'moment/locale/pt';
+import 'moment/locale/el';
+import 'moment/locale/cs';
 import 'moment/locale/ja';
 
 import { DomSanitizer, SafeUrl } from '@angular/platform-browser';


### PR DESCRIPTION
## Description

A proposed fixed for #1168.

The issue is that passing a non imported locale string in `moment.locale(settingLanguage);`, the retrieved locale is the last one imported instead of the English default.

The new function `setMomentLocale()` seems to fix the bug. Also each supported language in the app needs a dedicated Moment,js `import` in order to display the date locale properly. And now an unrecognized/not imported language will be display the date locale in English.

#### Notes:
- `no` is not a recognized locale for Norsk in Moment.js, so in order to not modify other parts of the app, a quick fix is implemented in the new function.
- I wrote the language imports in the same order as they are in the settings page, to maintain consistency.
- Android testing was made on a physical device.

## GitHub Issue / Discussion Reference

<!-- Please point to the GitHub issue or discussion ticket for this PR (e.g. Closes #123, Fixes #456, or paste link to ticket). -->

Ref / Closes: #1168 

## AI Assistance Disclosure

Used AI for troubleshooting, writing code, research, and understanding Norsk 😁

### AI Usage Level

- [ ] Completely on my own (0% AI)
- [ ] Assisted by AI (up to 50% AI)
- [X] Completely or mostly generated by AI (50% - 100% AI)

### AI Provider / Tool

<!-- If AI was used, please state the provider or tool name (e.g. GitHub Copilot, Gemini Antigravity, Claude, ChatGPT, Cursor, etc.) -->

- **Github Copilot in VSCode**
- **ChatGPT**

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring / Code cleanup
- [ ] Documentation update
- [ ] Other (please describe):

## Screenshots / Videos (if applicable)

<img width="720" height="1600" alt="Screenshot_2026-08-26-16-29-01-876_com beanconqueror app" src="https://github.com/user-attachments/assets/55c9b5f9-933d-4763-8325-f99d7c9da151" />

<img width="720" height="1600" alt="Screenshot_2026-08-26-17-07-25-553_com beanconqueror app" src="https://github.com/user-attachments/assets/7cbda04b-0119-490b-a7e9-cb891c296611" />

<img width="720" height="731" alt="Screenshot_2026-08-26-19-50-58-881-edit_com beanconqueror app" src="https://github.com/user-attachments/assets/b2bcea92-9cb7-477b-b0af-32683ceea076" />

## Tested Platforms

- [X] Android
- [ ] iOS
- [X] Web

## Checklist

- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings or lint errors
